### PR TITLE
build book on main

### DIFF
--- a/.github/workflows/build_book.yml
+++ b/.github/workflows/build_book.yml
@@ -2,10 +2,10 @@ name: Rebuild and deploy book to gh-pages branch
 on:
   push:
     branches:
-      - production
+      - main
     paths:
       - source/**
-      
+
 jobs:
   deploy-book:
     runs-on: ubuntu-latest
@@ -17,8 +17,8 @@ jobs:
       - name: checkout
         uses: actions/checkout@v2
         with:
-          ref: 'production'
-          
+          ref: 'main'
+
       - name: Build the book
         run: |
           ./build_html.sh


### PR DESCRIPTION
It would be great if we could deploy from main, at least for this term so that edits go live immediately (otherwise, I am likely to forget the extra pr to production!). Once it stabilizes, we could switch back to production 