### PR TITLE
Don't explicitly important altair_saver

### DIFF
--- a/source/viz.md
+++ b/source/viz.md
@@ -1881,8 +1881,6 @@ we demonstrate how to save PNG and SVG file types for the
 `faithful_scatter_labels` plot.
 
 ```{code-cell} ipython3
-from altair_saver import save
-
 faithful_scatter_labels.save("img/faithful_plot.png")
 faithful_scatter_labels.save("img/faithful_plot.svg")
 


### PR DESCRIPTION
I just noticed this when looking around for a large data section in the viz chapter. We should not need to explicitly important altair saver like that, and we are not actually using that function anyways when doing `chart.save`. Let me know if there was a reason for doing this that I'm missing.