### PR TITLE
Change `code` to `text` language tags

### DIFF
--- a/source/intro.md
+++ b/source/intro.md
@@ -245,7 +245,7 @@ is included with [the code for this book](https://github.com/UBC-DSCI/introducti
 If we were to open this data in a plain text editor (a program like Notepad that just shows
 text with no formatting), we would see each row on its own line, and each entry in the table separated by a comma:
 
-```code
+```text
 category,language,mother_tongue,most_at_home,most_at_work,lang_known
 Aboriginal languages,"Aboriginal languages, n.o.s.",590,235,30,665
 Non-Official & Non-Aboriginal languages,Afrikaans,10260,4785,85,23415

--- a/source/reading.md
+++ b/source/reading.md
@@ -194,7 +194,7 @@ name when we are loading the data set because this data set is located in a
 sub-folder, named `data`, relative to where we are running our Python code.
 Here is what the text in the file `data/can_lang.csv` looks like.
 
-```code
+```text
 category,language,mother_tongue,most_at_home,most_at_work,lang_known
 Aboriginal languages,"Aboriginal languages, n.o.s.",590,235,30,665
 Non-Official & Non-Aboriginal languages,Afrikaans,10260,4785,85,23415
@@ -237,7 +237,7 @@ gives the data scientist useful context and information about the data,
 however, it is not well formatted or intended to be read into a data frame cell
 along with the tabular data that follows later in the file.
 
-```code
+```text
 Data source: https://ttimbers.github.io/canlang/
 Data originally published in: Statistics Canada Census of Population 2016.
 Reproduced and distributed on an as-is basis with their permission.
@@ -261,7 +261,7 @@ message, indicating that it wasn't able to read the file.
 ```python
 canlang_data = pd.read_csv("data/can_lang_meta-data.csv")
 ```
-```code
+```text
 ParserError: Error tokenizing data. C error: Expected 1 fields in line 4, saw 6
 ```
 
@@ -286,7 +286,7 @@ canlang_data
 How did we know to skip three rows? We looked at the data! The first three rows
 of the data had information we didn't need to import:
 
-```code
+```text
 Data source: https://ttimbers.github.io/canlang/
 Data originally published in: Statistics Canada Census of Population 2016.
 Reproduced and distributed on an as-is basis with their permission.
@@ -300,7 +300,7 @@ Another common way data is stored is with tabs as the separator. Notice the
 data file, `can_lang.tsv`, has tabs in between the columns instead of
 commas.
 
-```code
+```text
 category	language	mother_tongue	most_at_home	most_at_work	lang_known
 Aboriginal languages	Aboriginal languages, n.o.s.	590	235	30	665
 Non-Official & Non-Aboriginal languages	Afrikaans	10260	4785	85	23415
@@ -355,7 +355,7 @@ The `can_lang_no_names.tsv` file contains a slightly different version
 of this data set, except with no column names, and tabs for separators.
 Here is how the file looks in a text editor:
 
-```code
+```text
 Aboriginal languages	Aboriginal languages, n.o.s.	590	235	30	665
 Non-Official & Non-Aboriginal languages	Afrikaans	10260	4785	85	23415
 Non-Official & Non-Aboriginal languages	Afro-Asiatic languages, n.i.e.	1150	445	10	2775
@@ -495,7 +495,7 @@ files. Take a look at a snippet of what a `.xlsx` file would look like in a text
 
 +++
 
-```code
+```text
 ,?'O
     _rels/.rels???J1??>E?{7?
 <?V????w8?'J???'QrJ???Tf?d??d?o?wZ'???@>?4'?|??hlIo??F
@@ -1202,7 +1202,7 @@ no_official_lang_data.to_csv("data/no_official_languages.csv", index=False)
 %
 % +++
 %
-% ```code
+% ```text
 % td:nth-child(8) ,
 % td:nth-child(6) ,
 % td:nth-child(4) ,


### PR DESCRIPTION
Changing 
```
```code
```
to
```
```text
```

Before:

![image](https://github.com/UBC-DSCI/introduction-to-datascience-python/assets/5981307/3f7ff363-a180-4efb-b0e8-b69716968224)

![image](https://github.com/UBC-DSCI/introduction-to-datascience-python/assets/5981307/8bc1c7e2-6b90-468d-ae99-d7c5b964091d)


After:
![image](https://github.com/UBC-DSCI/introduction-to-datascience-python/assets/5981307/63420757-5f33-4278-affe-0260a7ca9250)

![image](https://github.com/UBC-DSCI/introduction-to-datascience-python/assets/5981307/9d042292-bf7e-4c6c-9d3f-80c9ee1c09c5)


No change in output, warnings gone, LGTM