### PR TITLE
Adding `?` to Ch1 but keeping `help` first

### DIFF
--- a/source/intro.md
+++ b/source/intro.md
@@ -1094,8 +1094,13 @@ The documentation for the read_csv function including a high-level description, 
 +++
 
 If you are working in a Jupyter Lab environment, there are some conveniences that will help you lookup function names
-and access the documentation.
-You can type the first characters of the function you want to use,
+and access the documentation. First, rather than `help`, you can use the more concise `?` character. So for example,
+to read the documentation for the `pd.read_csv` function, you can run the following code:
+```{code-cell} ipython3
+:tags: ["remove-output"]
+?pd.read_csv
+```
+You can also type the first characters of the function you want to use,
 and then press <kbd>Tab</kbd> to bring up small menu
 that shows you all the available functions
 that starts with those characters.


### PR DESCRIPTION
This is an alternative to #187 that keeps the more general `help` function first. 

(Also keeps the flow as-is, avoiding introducing Jupyter-only `?` and then later having a Jupyter-only section only to backtrack and introduce `help` later on.)