### PR TITLE
Use multi-line expressions more effectively

### DIFF
--- a/source/intro.md
+++ b/source/intro.md
@@ -710,10 +710,12 @@ Let's rewrite this code in a more readable format using multiline expressions.
 
 ```{code-cell} ipython3
 aboriginal_lang = can_lang.loc[
-  can_lang["category"] == "Aboriginal languages", ["language", "mother_tongue"]
+    can_lang["category"] == "Aboriginal languages",
+    ["language", "mother_tongue"]
 ]
 arranged_lang_sorted = aboriginal_lang.sort_values(
-  by='mother_tongue', ascending=False
+    by='mother_tongue',
+    ascending=False
 )
 ten_lang = arranged_lang_sorted.head(10)
 ```


### PR DESCRIPTION
I think it would be nice to put the parameters on their own lines when showing multiline expressions. I also changed the indent to 4 to match the rest of the book