### PR TITLE
Remove/replace loc[:, cols], implicit data frame conversion, using functions instead of methods, and inconsistent spacing

### DIFF
--- a/source/classification1.md
+++ b/source/classification1.md
@@ -341,7 +341,7 @@ points_df = pd.DataFrame(
 perim_concav_with_new_point_df = pd.concat((cancer, points_df), ignore_index=True)
 # Find the euclidean distances from the new point to each of the points
 # in the orginal dataset
-my_distances = euclidean_distances(perim_concav_with_new_point_df.loc[:, attrs])[
+my_distances = euclidean_distances(perim_concav_with_new_point_df[attrs])[
     len(cancer)
 ][:-1]
 ```
@@ -442,7 +442,7 @@ points_df2 = pd.DataFrame(
 perim_concav_with_new_point_df2 = pd.concat((cancer, points_df2), ignore_index=True)
 # Find the euclidean distances from the new point to each of the points
 # in the orginal dataset
-my_distances2 = euclidean_distances(perim_concav_with_new_point_df2.loc[:, attrs])[
+my_distances2 = euclidean_distances(perim_concav_with_new_point_df2[attrs])[
     len(cancer)
 ][:-1]
 glue("new_point_2_0", new_point[0])
@@ -778,7 +778,7 @@ points_df4 = pd.DataFrame(
 perim_concav_with_new_point_df4 = pd.concat((cancer, points_df4), ignore_index=True)
 # Find the euclidean distances from the new point to each of the points
 # in the orginal dataset
-my_distances4 = euclidean_distances(perim_concav_with_new_point_df4.loc[:, attrs])[
+my_distances4 = euclidean_distances(perim_concav_with_new_point_df4[attrs])[
     len(cancer)
 ][:-1]
 ```
@@ -1203,7 +1203,7 @@ attrs = ["Area", "Smoothness"]
 new_obs = pd.DataFrame({"Class": ["Unknown"], "Area": 400, "Smoothness": 0.135})
 unscaled_cancer["Class"] = unscaled_cancer["Class"].apply(class_dscp)
 area_smoothness_new_df = pd.concat((unscaled_cancer, new_obs), ignore_index=True)
-my_distances = euclidean_distances(area_smoothness_new_df.loc[:, attrs])[
+my_distances = euclidean_distances(area_smoothness_new_df[attrs])[
     len(unscaled_cancer)
 ][:-1]
 area_smoothness_new_point = (
@@ -1279,7 +1279,7 @@ scaled_cancer_all["Class"] = scaled_cancer_all["Class"].apply(class_dscp)
 area_smoothness_new_df_scaled = pd.concat(
     (scaled_cancer_all, new_obs_scaled), ignore_index=True
 )
-my_distances_scaled = euclidean_distances(area_smoothness_new_df_scaled.loc[:, attrs])[
+my_distances_scaled = euclidean_distances(area_smoothness_new_df_scaled[attrs])[
     len(scaled_cancer_all)
 ][:-1]
 area_smoothness_new_point_scaled = (
@@ -1472,7 +1472,7 @@ new_point_df = pd.DataFrame(
 )
 rare_cancer["Class"] = rare_cancer["Class"].apply(class_dscp)
 rare_cancer_with_new_df = pd.concat((rare_cancer, new_point_df), ignore_index=True)
-my_distances = euclidean_distances(rare_cancer_with_new_df.loc[:, attrs])[
+my_distances = euclidean_distances(rare_cancer_with_new_df[attrs])[
     len(rare_cancer)
 ][:-1]
 
@@ -1538,7 +1538,7 @@ always "benign," corresponding to the blue color.
 :tags: [remove-cell]
 
 knn = KNeighborsClassifier(n_neighbors=7)
-knn.fit(X=rare_cancer.loc[:, ["Perimeter", "Concavity"]], y=rare_cancer["Class"])
+knn.fit(X=rare_cancer[["Perimeter", "Concavity"]], y=rare_cancer["Class"])
 
 # create a prediction pt grid
 per_grid = np.linspace(
@@ -1657,7 +1657,7 @@ closer to the benign tumor observations.
 
 knn = KNeighborsClassifier(n_neighbors=7)
 knn.fit(
-    X=upsampled_cancer.loc[:, ["Perimeter", "Concavity"]], y=upsampled_cancer["Class"]
+    X=upsampled_cancer[["Perimeter", "Concavity"]], y=upsampled_cancer["Class"]
 )
 
 # create a prediction pt grid

--- a/source/classification2.md
+++ b/source/classification2.md
@@ -1196,10 +1196,11 @@ and print the `info` of the result.
 
 ```{code-cell} ipython3
 accuracies_grid = pd.DataFrame(
-             cancer_tune_grid
-             .fit(cancer_train[["Smoothness", "Concavity"]],
-                  cancer_train["Class"]
-            ).cv_results_)
+    cancer_tune_grid.fit(
+        cancer_train[["Smoothness", "Concavity"]],
+        cancer_train["Class"]
+    ).cv_results_
+)
 ```
 
 ```{code-cell} ipython3
@@ -1220,14 +1221,16 @@ We will also rename the parameter name column to be a bit more readable,
 and drop the now unused `std_test_score` column.
 
 ```{code-cell} ipython3
-accuracies_grid = accuracies_grid[["param_kneighborsclassifier__n_neighbors", "mean_test_score", "std_test_score"]
-              ].assign(
-                  sem_test_score = accuracies_grid["std_test_score"] / 10**(1/2)
-              ).rename(
-                  columns = {"param_kneighborsclassifier__n_neighbors" : "n_neighbors"}
-              ).drop(
-                  columns = ["std_test_score"]
-              )
+accuracies_grid = (
+    accuracies_grid[[
+        "param_kneighborsclassifier__n_neighbors",
+        "mean_test_score",
+        "std_test_score"
+    ]]
+    .assign(sem_test_score=accuracies_grid["std_test_score"] / 10**(1/2))
+    .rename(columns={"param_kneighborsclassifier__n_neighbors": "n_neighbors"})
+    .drop(columns=["std_test_score"])
+)
 accuracies_grid
 ```
 

--- a/source/classification2.md
+++ b/source/classification2.md
@@ -599,7 +599,7 @@ from sklearn.pipeline import make_pipeline
 
 knn = KNeighborsClassifier(n_neighbors=3) 
 
-X = cancer_train.loc[:, ["Smoothness", "Concavity"]]
+X = cancer_train[["Smoothness", "Concavity"]]
 y = cancer_train["Class"]
 
 knn_fit = make_pipeline(cancer_preprocessor, knn).fit(X, y)
@@ -622,7 +622,7 @@ variables in the output data frame.
 
 ```{code-cell} ipython3
 cancer_test_predictions = cancer_test.assign(
-    predicted = knn_fit.predict(cancer_test.loc[:, ["Smoothness", "Concavity"]])
+    predicted = knn_fit.predict(cancer_test[["Smoothness", "Concavity"]])
 )
 cancer_test_predictions[['ID', 'Class', 'predicted']]
 ```
@@ -890,13 +890,13 @@ cancer_subtrain, cancer_validation = train_test_split(
 
 # fit the model on the sub-training data
 knn = KNeighborsClassifier(n_neighbors=3) 
-X = cancer_subtrain.loc[:, ["Smoothness", "Concavity"]]
+X = cancer_subtrain[["Smoothness", "Concavity"]]
 y = cancer_subtrain["Class"]
 knn_fit = make_pipeline(cancer_preprocessor, knn).fit(X, y)
 
 # compute the score on validation data
 acc = knn_fit.score(
-    cancer_validation.loc[:, ["Smoothness", "Concavity"]],
+    cancer_validation[["Smoothness", "Concavity"]],
     cancer_validation["Class"]
 )
 acc
@@ -914,13 +914,13 @@ for i in range(1, 5):
 
     # fit the model on the sub-training data
     knn = KNeighborsClassifier(n_neighbors=3) 
-    X = cancer_subtrain.loc[:, ["Smoothness", "Concavity"]]
+    X = cancer_subtrain[["Smoothness", "Concavity"]]
     y = cancer_subtrain["Class"]
     knn_fit = make_pipeline(cancer_preprocessor, knn).fit(X, y)
 
     # compute the score on validation data
     accuracies.append(knn_fit.score(
-        cancer_validation.loc[:, ["Smoothness", "Concavity"]],
+        cancer_validation[["Smoothness", "Concavity"]],
         cancer_validation["Class"]
        ))
 avg_accuracy = np.round(np.array(accuracies).mean()*100,1)
@@ -996,7 +996,7 @@ from sklearn.model_selection import cross_validate
 
 knn = KNeighborsClassifier(n_neighbors=3) 
 cancer_pipe = make_pipeline(cancer_preprocessor, knn)
-X = cancer_train.loc[:, ["Smoothness", "Concavity"]]
+X = cancer_train[["Smoothness", "Concavity"]]
 y = cancer_train["Class"]
 cv_5_df = pd.DataFrame(
     cross_validate(
@@ -1197,7 +1197,7 @@ and print the `info` of the result.
 ```{code-cell} ipython3
 accuracies_grid = pd.DataFrame(
              cancer_tune_grid
-             .fit(cancer_train.loc[:, ["Smoothness", "Concavity"]],
+             .fit(cancer_train[["Smoothness", "Concavity"]],
                   cancer_train["Class"]
             ).cv_results_)
 ```
@@ -1314,7 +1314,7 @@ large_cancer_tune_grid = GridSearchCV(
 
 large_accuracies_grid = pd.DataFrame(
     large_cancer_tune_grid.fit(
-        cancer_train.loc[:, ["Smoothness", "Concavity"]],
+        cancer_train[["Smoothness", "Concavity"]],
         cancer_train["Class"]
     ).cv_results_
 )
@@ -1404,7 +1404,7 @@ cancer_plot = (
     )
 )
 
-X = cancer_train.loc[:, ["Smoothness", "Concavity"]]
+X = cancer_train[["Smoothness", "Concavity"]]
 y = cancer_train["Class"]
 
 # create a prediction pt grid

--- a/source/clustering.md
+++ b/source/clustering.md
@@ -292,7 +292,7 @@ have.
 ```{code-cell} ipython3
 :tags: [remove-cell]
 
-clus = data[data["cluster"] == 2].loc[:,["bill_length_standardized", "flipper_length_standardized"]]
+clus = data[data["cluster"] == 2][["bill_length_standardized", "flipper_length_standardized"]]
 ```
 
 ```{index} see: within-cluster sum-of-squared-distances; WSSD

--- a/source/regression1.md
+++ b/source/regression1.md
@@ -611,7 +611,7 @@ and rename the parameter column to be more readable.
 ```{code-cell} ipython3
 # fit the GridSearchCV object
 sacr_fit = sacr_gridsearch.fit(
-    sacramento_train[["sqft"]],  # A single column data frame
+    sacramento_train[["sqft"]],  # A single-column data frame
     sacramento_train["price"]  # A series
 )
 

--- a/source/regression1.md
+++ b/source/regression1.md
@@ -306,7 +306,7 @@ of a house that is 2,000 square feet.
 
 ```{code-cell} ipython3
 nearest_neighbors = (
-    small_sacramento.assign(diff=abs(2000 - small_sacramento["sqft"]))
+    small_sacramento.assign(diff=(2000 - small_sacramento["sqft"]).abs())
     .nsmallest(5, "diff")
 )
 
@@ -1018,7 +1018,7 @@ sacr_results["mean_test_score"] = -sacr_results["mean_test_score"]
 
 # show only the row of minimum RMSPE
 sacr_results[
-   sacr_results["mean_test_score"] == min(sacr_results["mean_test_score"])
+   sacr_results["mean_test_score"] == sacr_results["mean_test_score"].min()
 ]
 ```
 

--- a/source/regression1.md
+++ b/source/regression1.md
@@ -186,7 +186,7 @@ want to predict (sale price) on the y-axis.
 ```{code-cell} ipython3
 :tags: [remove-output]
 
-eda = alt.Chart(sacramento).mark_circle().encode(
+scatter = alt.Chart(sacramento).mark_circle().encode(
     x=alt.X("sqft")
         .scale(zero=False)
         .title("House size (square feet)"),
@@ -195,12 +195,12 @@ eda = alt.Chart(sacramento).mark_circle().encode(
         .title("Price (USD)")
 )
 
-eda
+scatter
 ```
 
 ```{code-cell} ipython3
 :tags: [remove-cell]
-glue("fig:07-edaRegr", eda)
+glue("fig:07-edaRegr", scatter)
 ```
 
 :::{glue:figure} fig:07-edaRegr

--- a/source/regression1.md
+++ b/source/regression1.md
@@ -600,19 +600,20 @@ and rename the parameter column to be more readable.
 ```{code-cell} ipython3
 # fit the GridSearchCV object 
 sacr_fit = sacr_gridsearch.fit(
-                  sacramento_train[["sqft"]],
-                  sacramento_train[["price"]]
-              )
-# retrieve the CV scores
-sacr_results = pd.DataFrame(sacr_fit.cv_results_)[
-    ["param_kneighborsregressor__n_neighbors", "mean_test_score", "std_test_score"]
-]
-sacr_results = sacr_results.assign(
-    sem_test_score = sacr_results["std_test_score"] / 5**(1/2)
-).rename(
-    columns = {"param_kneighborsregressor__n_neighbors" : "n_neighbors"}
-).drop(
-    columns = ["std_test_score"]
+    sacramento_train[["sqft"]],
+    sacramento_train[["price"]]
+)
+
+# Retrieve the CV scores
+sacr_results = (
+    pd.DataFrame(sacr_fit.cv_results_)[[
+        "param_kneighborsregressor__n_neighbors",
+        "mean_test_score",
+        "std_test_score"
+    ]]
+    .assign(sem_test_score=sacr_results["std_test_score"] / 5**(1/2))
+    .rename(columns={"param_kneighborsregressor__n_neighbors": "n_neighbors"})
+    .drop(columns=["std_test_score"])
 )
 sacr_results
 ```
@@ -826,7 +827,7 @@ model uses a different default scoring metric than the RMSPE.
 from sklearn.metrics import mean_squared_error
 
 sacr_preds = sacramento_test.assign(
-    predicted = sacr_fit.best_estimator_.predict(sacramento_test)
+    predicted=sacr_fit.best_estimator_.predict(sacramento_test)
 )
 RMSPE = mean_squared_error(
     y_true = sacr_preds["price"], 
@@ -871,7 +872,7 @@ generated it as a learning challenge.
 
 sacr_preds = pd.DataFrame({"sqft": np.arange(500, 5001, 10)})
 sacr_preds = sacr_preds.assign(
-                   predicted = sacr_fit.predict(sacr_preds)
+    predicted=sacr_fit.predict(sacr_preds)
 )
 
 # the base plot: the training data scatter plot
@@ -887,7 +888,10 @@ base_plot = alt.Chart(sacramento_train).mark_circle().encode(
 # add the prediction layer
 sacr_preds_plot = base_plot + alt.Chart(sacr_preds, title=f"K = {best_k_sacr}").mark_line(
     color="#ff7f0e"
-).encode(x="sqft", y="predicted")
+).encode(
+    x="sqft",
+    y="predicted"
+)
 
 sacr_preds_plot
 ```
@@ -1000,16 +1004,16 @@ sacr_fit = GridSearchCV(
     )
 
 # retrieve the CV scores
-sacr_results = pd.DataFrame(sacr_fit.cv_results_)[
-    ["param_kneighborsregressor__n_neighbors", "mean_test_score", "std_test_score"]
-]
-sacr_results = sacr_results.assign(
-    sem_test_score = sacr_results["std_test_score"] / 5**(1/2)
-).rename(
-    columns = {"param_kneighborsregressor__n_neighbors" : "n_neighbors"}
-).drop(
-    columns = ["std_test_score"]
-)
+sacr_results = (
+    pd.DataFrame(sacr_fit.cv_results_)[[
+        "param_kneighborsregressor__n_neighbors",
+        "mean_test_score",
+        "std_test_score"
+    ]]
+    .assign(sem_test_score=sacr_results["std_test_score"] / 5**(1/2))
+    .rename(columns={"param_kneighborsregressor__n_neighbors" : "n_neighbors"})
+    .drop(columns=["std_test_score"])
+
 sacr_results["mean_test_score"] = -sacr_results["mean_test_score"]
 
 # show only the row of minimum RMSPE

--- a/source/regression1.md
+++ b/source/regression1.md
@@ -596,16 +596,19 @@ on `sacr_gridsearch`. As we did in the {ref}`classification2` chapter,
 we will wrap the `cv_results_` output in a data frame, extract
 only the relevant columns, compute the standard error based on 5 folds, 
 and rename the parameter column to be more readable.
-In `scikit-learn`, it is easier to work with a data frame as the input features,
+In `scikit-learn`, it is easier to work with the input features as a data frame,
 rather than a series. So, when we select a single column,
-we explicitly convert the series to a data frame with the `to_frame()` method.
-The target variable can be a series, so we don't need to convert it to a data frame.
+we pass the name of the column as a list rather than a string
+to return a data frame
+as we learned in the {ref}`wrangling` chapter.
+The target variable can be a series,
+so we can pass its column name as a string.
 
 ```{code-cell} ipython3
 # fit the GridSearchCV object
 sacr_fit = sacr_gridsearch.fit(
-    sacramento_train["sqft"].to_frame(),
-    sacramento_train["price"]
+    sacramento_train[["sqft"]],  # A single column data frame
+    sacramento_train["price"]  # A series
 )
 
 # Retrieve the CV scores

--- a/source/regression1.md
+++ b/source/regression1.md
@@ -596,12 +596,16 @@ on `sacr_gridsearch`. As we did in the {ref}`classification2` chapter,
 we will wrap the `cv_results_` output in a data frame, extract
 only the relevant columns, compute the standard error based on 5 folds, 
 and rename the parameter column to be more readable.
+In `scikit-learn`, it is easier to work with a data frame as the input features,
+rather than a series. So, when we select a single column,
+we explicitly convert the series to a data frame with the `to_frame()` method.
+The target variable can be a series, so we don't need to convert it to a data frame.
 
 ```{code-cell} ipython3
-# fit the GridSearchCV object 
+# fit the GridSearchCV object
 sacr_fit = sacr_gridsearch.fit(
-    sacramento_train[["sqft"]],
-    sacramento_train[["price"]]
+    sacramento_train["sqft"].to_frame(),
+    sacramento_train["price"]
 )
 
 # Retrieve the CV scores
@@ -1000,7 +1004,7 @@ sacr_fit = GridSearchCV(
     scoring="neg_root_mean_squared_error"
     ).fit(
       sacramento_train[["sqft", "beds"]],
-      sacramento_train[["price"]]
+      sacramento_train["price"]
     )
 
 # retrieve the CV scores

--- a/source/regression1.md
+++ b/source/regression1.md
@@ -612,12 +612,13 @@ sacr_fit = sacr_gridsearch.fit(
 )
 
 # Retrieve the CV scores
+sacr_results = pd.DataFrame(sacr_fit.cv_results_)[[
+    "param_kneighborsregressor__n_neighbors",
+    "mean_test_score",
+    "std_test_score"
+]]
 sacr_results = (
-    pd.DataFrame(sacr_fit.cv_results_)[[
-        "param_kneighborsregressor__n_neighbors",
-        "mean_test_score",
-        "std_test_score"
-    ]]
+    sacr_results
     .assign(sem_test_score=sacr_results["std_test_score"] / 5**(1/2))
     .rename(columns={"param_kneighborsregressor__n_neighbors": "n_neighbors"})
     .drop(columns=["std_test_score"])
@@ -1014,15 +1015,18 @@ sacr_fit = GridSearchCV(
     )
 
 # retrieve the CV scores
+sacr_results = pd.DataFrame(sacr_fit.cv_results_)[[
+    "param_kneighborsregressor__n_neighbors",
+    "mean_test_score",
+    "std_test_score"
+]]
+
 sacr_results = (
-    pd.DataFrame(sacr_fit.cv_results_)[[
-        "param_kneighborsregressor__n_neighbors",
-        "mean_test_score",
-        "std_test_score"
-    ]]
+    sacr_results
     .assign(sem_test_score=sacr_results["std_test_score"] / 5**(1/2))
     .rename(columns={"param_kneighborsregressor__n_neighbors" : "n_neighbors"})
     .drop(columns=["std_test_score"])
+)
 
 sacr_results["mean_test_score"] = -sacr_results["mean_test_score"]
 

--- a/source/regression1.md
+++ b/source/regression1.md
@@ -592,17 +592,21 @@ sacr_gridsearch = GridSearchCV(
 ```
 
 Next, we use the run cross validation by calling the `fit` method
-on `sacr_gridsearch`. As we did in the {ref}`classification2` chapter,
+on `sacr_gridsearch`. Note the use of two brackets for the input features
+(`sacramento_train[["sqft"]]`), which creates a data frame with a single column.
+As we learned in the {ref}`wrangling` chapter, we can obtain a data frame with a 
+subset of columns by passing a list of column names; `["sqft"]` is a list with one
+item, so we obtain a data frame with one column. If instead we used 
+just one bracket (`sacramento_train["sqft"]`), we would obtain a series.
+In `scikit-learn`, it is easier to work with the input features as a data frame
+rather than a series, so we opt for two brackets here. On the other hand, the response variable
+can be a series, so we use just one bracket there (`sacramento_train["price"]`).
+
+As in the {ref}`classification2` chapter, once the model has been fit 
 we will wrap the `cv_results_` output in a data frame, extract
 only the relevant columns, compute the standard error based on 5 folds, 
 and rename the parameter column to be more readable.
-In `scikit-learn`, it is easier to work with the input features as a data frame,
-rather than a series. So, when we select a single column,
-we pass the name of the column as a list rather than a string
-to return a data frame
-as we learned in the {ref}`wrangling` chapter.
-The target variable can be a series,
-so we can pass its column name as a string.
+
 
 ```{code-cell} ipython3
 # fit the GridSearchCV object

--- a/source/regression2.md
+++ b/source/regression2.md
@@ -399,8 +399,8 @@ intercept of the line via the `intercept_` property.
 # fit the linear regression model
 lm = LinearRegression()
 lm.fit(
-   sacramento_train["sqft"].to_frame(),
-   sacramento_train["price"]
+   sacramento_train[["sqft"]],  # A single column data frame
+   sacramento_train["price"]  # A series
 )
 
 # make a dataframe containing slope and intercept coefficients

--- a/source/regression2.md
+++ b/source/regression2.md
@@ -399,21 +399,21 @@ intercept of the line via the `intercept_` property.
 # fit the linear regression model
 lm = LinearRegression()
 lm.fit(
-   sacramento_train[["sqft"]],  # A single column data frame
+   sacramento_train[["sqft"]],  # A single-column data frame
    sacramento_train["price"]  # A series
 )
 
 # make a dataframe containing slope and intercept coefficients
-pd.DataFrame({"slope": lm.coef_[0], "intercept": lm.intercept_})
+pd.DataFrame({"slope": [lm.coef_[0]], "intercept": [lm.intercept_]})
 ```
 
 ```{code-cell} ipython3
 :tags: [remove-cell]
 
-glue("train_lm_slope", round(lm.coef_[0][0]))
-glue("train_lm_intercept", round(lm.intercept_[0]))
-glue("train_lm_slope_f", "{0:,.0f}".format(lm.coef_[0][0]))
-glue("train_lm_intercept_f", "{0:,.0f}".format(lm.intercept_[0]))
+glue("train_lm_slope", round(lm.coef_[0]))
+glue("train_lm_intercept", round(lm.intercept_))
+glue("train_lm_slope_f", "{0:,.0f}".format(lm.coef_[0]))
+glue("train_lm_intercept_f", "{0:,.0f}".format(lm.intercept_))
 ```
 
 ```{index} standardization
@@ -446,7 +446,7 @@ we predict on the test data set to assess how well our model does.
 ```{code-cell} ipython3
 # make predictions
 sacr_preds = sacramento_test.assign(
-    predicted = lm.predict(sacramento_test["sqft"].to_frame())
+    predicted = lm.predict(sacramento_test[["sqft"]])
 )
 
 # calculate RMSPE
@@ -843,7 +843,7 @@ you will see that `mlm.coef_` above is just an array of values without any varia
 Unfortunately you have to do this mapping yourself: the coefficients in `mlm.coef_` appear
 in the *same order* as the columns of the predictor data frame you used when training.
 So since we used `sacramento_train[["sqft", "beds"]]` when training, 
-we have that `mlm.coef_[0][0]` corresponds to `sqft`, and `mlm.coef_[0][1]` corresponds to `beds`.
+we have that `mlm.coef_[0]` corresponds to `sqft`, and `mlm.coef_[1]` corresponds to `beds`.
 
 ```{index} plane equation
 ```
@@ -863,9 +863,9 @@ to create the equation of the plane of best fit to the data:
 ```{code-cell} ipython3
 :tags: [remove-cell]
 
-icept = "{0:,.0f}".format(mlm.intercept_[0])
-sqftc = "{0:,.0f}".format(mlm.coef_[0][0])
-bedsc = "{0:,.0f}".format(mlm.coef_[0][1])
+icept = "{0:,.0f}".format(mlm.intercept_)
+sqftc = "{0:,.0f}".format(mlm.coef_[0])
+bedsc = "{0:,.0f}".format(mlm.coef_[1])
 glue("icept", icept)
 glue("sqftc", sqftc)
 glue("bedsc", bedsc)
@@ -1177,11 +1177,11 @@ has regression coefficients that are very sensitive to the exact values in the d
 if we change the data ever so slightly&mdash;e.g., by running cross-validation, which splits
 up the data randomly into different chunks&mdash;the coefficients vary by large amounts:
 
-Best Fit 1: $\text{house sale price} =$ {glue:text}`icept1` $+$ {glue:text}`sqft1` $\cdot (\text{house size 1}$ $({ft}^2)) +$ {glue:text}`sqft11` $\cdot (\text{house size 2}$ $({ft}^2)).$
+Best Fit 1: $\text{house sale price} =$ {glue:text}`icept1` $+$ {glue:text}`sqft1` $\cdot (\text{house size 1}$ $(\text{ft}^2)) +$ {glue:text}`sqft11` $\cdot (\text{house size 2}$ $(\text{ft}^2)).$
 
-Best Fit 2: $\text{house sale price} =$ {glue:text}`icept2` $+$ {glue:text}`sqft2` $\cdot (\text{house size 1}$ $({ft}^2)) +$ {glue:text}`sqft22` $\cdot (\text{house size 2}$ $({ft}^2)).$
+Best Fit 2: $\text{house sale price} =$ {glue:text}`icept2` $+$ {glue:text}`sqft2` $\cdot (\text{house size 1}$ $(\text{ft}^2)) +$ {glue:text}`sqft22` $\cdot (\text{house size 2}$ $(\text{ft}^2)).$
 
-Best Fit 3: $\text{house sale price} =$ {glue:text}`icept3` $+$ {glue:text}`sqft3` $\cdot (\text{house size 1}$ $({ft}^2)) +$ {glue:text}`sqft33` $\cdot (\text{house size 2}$ $({ft}^2)).$
+Best Fit 3: $\text{house sale price} =$ {glue:text}`icept3` $+$ {glue:text}`sqft3` $\cdot (\text{house size 1}$ $(\text{ft}^2)) +$ {glue:text}`sqft33` $\cdot (\text{house size 2}$ $(\text{ft}^2)).$
 
  Therefore, when performing multivariable linear regression, it is important to avoid including very
 linearly related predictors. However, techniques for doing so are beyond the scope of this

--- a/source/regression2.md
+++ b/source/regression2.md
@@ -399,8 +399,8 @@ intercept of the line via the `intercept_` property.
 # fit the linear regression model
 lm = LinearRegression()
 lm.fit(
-   sacramento_train[["sqft"]],
-   sacramento_train[["price"]]
+   sacramento_train["sqft"].to_frame(),
+   sacramento_train["price"]
 )
 
 # make a dataframe containing slope and intercept coefficients
@@ -446,7 +446,7 @@ we predict on the test data set to assess how well our model does.
 ```{code-cell} ipython3
 # make predictions
 sacr_preds = sacramento_test.assign(
-    predicted = lm.predict(sacramento_test[["sqft"]])
+    predicted = lm.predict(sacramento_test["sqft"].to_frame())
 )
 
 # calculate RMSPE
@@ -728,7 +728,7 @@ method as usual.
 
 mlm = LinearRegression().fit(
     sacramento_train[["sqft", "beds"]],
-    sacramento_train[["price"]]
+    sacramento_train["price"]
 )
 ```
 Finally, we make predictions on the test data set to assess the quality of our model.

--- a/source/wrangling.md
+++ b/source/wrangling.md
@@ -847,7 +847,7 @@ one can use in the `[]` to select subsets of rows.
 
 ### Extracting columns by name
 
-Recall that if we provide a list of column names, `[]` returns the subset of columns with those names.
+Recall that if we provide a list of column names, `[]` returns the subset of columns with those names as a data frame.
 Suppose we wanted to select the columns `language`, `region`,
 `most_at_home` and `most_at_work` from the `tidy_lang` data set. Using what we
 learned in the chapter on {ref}`intro`, we can pass all of these column 
@@ -856,6 +856,28 @@ names into the square brackets.
 ```{code-cell} ipython3
 :tags: ["output_scroll"]
 tidy_lang[["language", "region", "most_at_home", "most_at_work"]]
+```
+
+Likewise,
+if we pass a list containing a single column name,
+a data frame with this column will be returned.
+
+```{code-cell} ipython3
+:tags: ["output_scroll"]
+tidy_lang[["language"]]
+```
+
+When we need to extract only a single column,
+we can also pass the column name as a string rather than a list.
+The returned data type will now be a series.
+Throughout this textbook,
+we will mostly extract single columns this way,
+but we will point out a few occasions
+where it is advantageous to extract single columns as data frames.
+
+```{code-cell} ipython3
+:tags: ["output_scroll"]
+tidy_lang["language"]
 ```
 
 


### PR DESCRIPTION
These are a few fixes that are not necessarily related but touch the same bit of code so it would lead to conflicts to make them as separate PRs. Happy to roll back individual commits if there is something that is not suitable.

- Remove use of `loc[:, list_of_cols]`
- Improve code formatting
- Prefer data frame methods over global functions
- Explain why we are converting to a data frame and be explicit and consistent when we do it
