### PR TITLE
Various compilation fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,10 @@ RUN pip install referencing
 RUN pip install jupyter-book
 RUN pip install numpy jinja2 altair_data_server vl-convert-python click ibis-framework ghp-import jupytext nodejs
 
+# forces scikit-learn to grab latest to avoid bug in 1.3.0 related to checking for c-contiguity breaking figures in classification 2. See https://github.com/scikit-learn/scikit-learn/pull/26772
+# TODO: remove this once scikit-learn 1.4.x or beyond releases and is incorporated into jupyter/scipy-notebook
+RUN pip install -U git+https://github.com/scikit-learn/scikit-learn.git@main
+
 # disable warnings that pollute build logs; seems to be related to the update to python 3.11
 # https://discourse.jupyter.org/t/debugger-warning-it-seems-that-frozen-modules-are-being-used-python-3-11-0/16544/12
 ENV PYDEVD_DISABLE_FILE_VALIDATION=1

--- a/source/clustering.md
+++ b/source/clustering.md
@@ -146,7 +146,7 @@ To learn about K-means clustering
 we will work with `penguin_data` in this chapter.
 `penguin_data` is a subset of 18 observations of the original data,
 which has already been standardized
-(remember from Chapter {ref}`classification`
+(remember from Chapter {ref}`classification1`
 that scaling is part of the standardization process).
 We will discuss scaling for K-means in more detail later in this chapter.
 
@@ -350,7 +350,7 @@ The second step in computing the WSSD is to add up the squared distance
 between each point in the cluster
 and the cluster center.
 We use the straight-line / Euclidean distance formula
-that we learned about in Chapter {ref}`classification`.
+that we learned about in Chapter {ref}`classification1`.
 In the {glue:}`clus_rows_glue`-observation cluster example above,
 we would compute the WSSD $S^2$ via
 

--- a/source/intro.md
+++ b/source/intro.md
@@ -171,7 +171,7 @@ This is covered in detail in the {ref}`viz` chapter, but again appears regularly
 Classification is used to answer predictive questions.
 For example, you might use classification to answer the following question:
 *Given measurements of a tumor's average cell area and perimeter, is the tumor benign or malignant?*
-Classification is covered in the {ref}`classification` and {ref}`classification2` chapters.
+Classification is covered in the {ref}`classification1` and {ref}`classification2` chapters.
 4. **Regression:** predicting a quantitative value for a new observation.
 Regression is also used to answer predictive questions.
 For example, you might use regression to answer the following question:

--- a/source/regression1.md
+++ b/source/regression1.md
@@ -52,7 +52,7 @@ we will split our data into training, validation, and test sets, we will
 use `scikit-learn` workflows, we will use a K-nearest neighbors (KNN)
 approach to make predictions, and we will use cross-validation to choose K.
 Because of how similar these procedures are, make sure to read the
-{ref}`classification` and {ref}`classification2` chapters before reading
+{ref}`classification1` and {ref}`classification2` chapters before reading
 this one&mdash;we will move a little bit faster here with the
 concepts that have already been covered.
 This chapter will primarily focus on the case where there is a single predictor,
@@ -565,7 +565,7 @@ So we need to specify that we want to use the RMSPE for tuning by setting the
 
 > **Note:** We obtained the identifier of the parameter representing the number
 > of neighbours, `"kneighborsregressor__n_neighbors"` by examining the output
-> of `sacr_pipeline.get_params()`, as we did in the {ref}`classification`
+> of `sacr_pipeline.get_params()`, as we did in the {ref}`classification1`
 > chapter.
 
 ```{index} scikit-learn; GridSearchCV

--- a/source/version-control.md
+++ b/source/version-control.md
@@ -556,6 +556,7 @@ be human-readable. Committing one big archive defeats the whole purpose of using
 version control: you won't be able to see, interpret, or find changes in the history
 of any of the actual content of your project!
 
+(local-repo-jupyter)=
 ## Working with local repositories using Jupyter
 
 ```{index} git;Jupyter extension


### PR DESCRIPTION
Closes #204 

- fixes `{ref}classification` to `{ref}classification1`
- adds the missing ref in version control
- pins `scikit-learn` to the latest (due to an important PR that was merged shortly after the current 1.3.0 release, see https://github.com/scikit-learn/scikit-learn/pull/26772 -- 1.3.0 breaks a few figures in classification 2)
- ~~removes duplicate bib entries~~ there are none. it looks like it's related to having the same citation appear across multiple md files https://github.com/mcmtroffaes/sphinxcontrib-bibtex/issues/243 . The warnings will persist but there is no actual issue in the compiled doc, so I'm going to leave this as-is.