### PR TITLE
Trigger Dockerfile rebuild/commit on PR

### DIFF
--- a/.github/workflows/update_build_environment.yml
+++ b/.github/workflows/update_build_environment.yml
@@ -1,8 +1,6 @@
 name: Rebuild and publish new ubcdsci/py-intro-to-ds image on DockerHub
 on:
-  push:
-    branches:
-      - main
+  pull_request:
     paths:
       - Dockerfile
 jobs:
@@ -11,11 +9,11 @@ jobs:
     permissions:
       contents: write
     steps:
-    - name: Checkout main
+    - name: Checkout PR branch
       uses: actions/checkout@v3
       with:
         fetch-depth: '0'
-        ref: 'main'
+        ref: ${{ github.head_ref }}
     - name: Rebuild and publish image
       id: rebuild
       uses: elgohr/Publish-Docker-Github-Action@v5
@@ -29,7 +27,7 @@ jobs:
       run: |
         git config --local user.email "action@github.com"
         git config --local user.name "GitHub Action"
-        git pull origin main
+        git pull origin ${{ github.head_ref }}
         sed 's/ubcdsci\/py-intro-to-ds:[[:alnum:]]\+/ubcdsci\/py-intro-to-ds:${{ steps.rebuild.outputs.snapshot-tag }}/g' build_html.sh > build_html.tmp && mv build_html.tmp build_html.sh
         chmod u+x build_html.sh
         git add build_html.sh
@@ -38,7 +36,7 @@ jobs:
       run: |
         git config --local user.email "action@github.com"
         git config --local user.name "GitHub Action"
-        git pull origin main
+        git pull origin ${{ github.head_ref }}
         sed 's/ubcdsci\/py-intro-to-ds:[[:alnum:]]\+/ubcdsci\/py-intro-to-ds:${{ steps.rebuild.outputs.snapshot-tag }}/g' build_pdf.sh > build_pdf.tmp && mv build_pdf.tmp build_pdf.sh
         chmod u+x build_pdf.sh
         git add build_pdf.sh
@@ -47,4 +45,4 @@ jobs:
       uses: ad-m/github-push-action@master
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
-        branch: 'main'
+        branch: ${{ github.head_ref }}


### PR DESCRIPTION
This PR would edit the github action to rebuild the docker image when a PR is opened targeting `Dockerfile`. That would let us easily review PRs that edit the Dockerfile without needing to manually build things locally or interactively before testing.

One TODO: I would need to enable `main` branch protection to stop accidental commits to `Dockerfile` directly, which would circumvent the action.

There is one problem with this approach: if someone else were to fork this repo and make a PR that edits the `Dockerfile`, the workflow would fail. That is very unlikely to happen, so maybe the benefit of being able to check the build on most PRs is worth it.

Another approach would be to have github action build a copy of the book using dockerhub, or if it can't find the image, build the image first locally w/o pushing to dockerhub. That would work with forks, and would enable PR review without needing to build the image locally. Big downside is needing to enable an app (netlify etc) to have permissions in our repos, which I'm not a fan of.

Closes #221 

(We should take the same approach in the R book repo)

@joelostblom thoughts?