### PR TITLE
Revert "Shallower subheading labelling"

### DIFF
--- a/source/_toc.yml
+++ b/source/_toc.yml
@@ -8,7 +8,7 @@ parts:
     - file: acknowledgements.md
     - file: authors.md
 - caption: Chapters
-  numbered: 2
+  numbered: 3
   chapters:
     - file: intro.md
     - file: reading.md

--- a/source/viz.md
+++ b/source/viz.md
@@ -54,7 +54,7 @@ By the end of the chapter, readers will be able to do the following:
 
 ## Choosing the visualization
 
-#### *Ask a question, and answer it*
+<font size="5">*Ask a question, and answer it*</font>
 
 ```{index} question; visualization
 ```
@@ -118,7 +118,7 @@ alternative.
 
 ## Refining the visualization
 
-#### *Convey the message, minimize noise*
+<font size="5">*Convey the message, minimize noise*</font>
 
 Just being able to make a visualization in Python with `altair` (or any other tool
 for that matter) doesn't mean that it effectively communicates your message to
@@ -160,7 +160,8 @@ understand and remember your message quickly.
 +++
 
 ## Creating visualizations with `altair`
-#### *Build the visualization iteratively*
+
+<font size="5">*Build the visualization iteratively*</font>
 
 ```{index} altair
 ```
@@ -1799,7 +1800,7 @@ Effect of varying number of max bins on histograms.
 :::
 
 ## Explaining the visualization
-#### *Tell a story*
+<font size="5">*Tell a story*</font>
 
 Typically, your visualization will not be shown entirely on its own, but rather
 it will be part of a larger presentation.  Further, visualizations can provide
@@ -1872,7 +1873,8 @@ result. (4) It would be worth further investigating the differences between
 these experiments to see why they produced different results.
 
 ## Saving the visualization
-#### *Choose the right output format for your needs*
+
+<font size="5">*Choose the right output format for your needs*</font>
 
 ```{index} see: bitmap; raster graphics
 ```


### PR DESCRIPTION
@trevorcampbell I just realized something after you merged https://github.com/UBC-DSCI/introduction-to-datascience-python/pull/245. The heading level to number was already set to 3, so we shouldn't need to set it to 2, since the heading we are trying to control is a fourth level heading. I think what actually is happening is that jupyter book does not allow non-consecutive jumps in headings levels. So since we went from a second level to a fourth level heading in the viz chapter, the latter was promoted to a third level heading which used to be numbered in the old config. I don't know if there is a way around this in jupyter book and allow for non-consecutive jumps, but we should revert that PR since it causes an issue with all other third level headings which are not longer numbered
![image](https://github.com/UBC-DSCI/introduction-to-datascience-python/assets/4560057/b116fb5d-03e9-48be-beab-5e128ffee01b)