### PR TITLE
Remove todo comment

### DIFF
--- a/source/wrangling.md
+++ b/source/wrangling.md
@@ -627,8 +627,6 @@ Going from long to wide with the `pivot` function.
 
 {numref}`fig:img-pivot-wider` details the arguments that we need to specify in the `pivot` function.
 
-**TODO make figure match code below**
-
 +++ {"tags": []}
 
 ```{figure} img/wrangling/pandas_pivot_args_labels.png


### PR DESCRIPTION
Looks like this was fixed and we just forgot to delete the comment. From the live book:


![image](https://github.com/UBC-DSCI/introduction-to-datascience-python/assets/4560057/4df85a2d-5d58-42f4-8d62-e6e207f74948)

