### PR TITLE
Consistent glued number formatting

### DIFF
--- a/source/_static/style.css
+++ b/source/_static/style.css
@@ -25,3 +25,7 @@ img {
     margin-left: auto;
     margin-right: auto;
 }
+
+span.pasted-text {
+	font-weight: normal;
+}

--- a/source/classification1.md
+++ b/source/classification1.md
@@ -233,10 +233,10 @@ cancer["Class"].unique()
 
 ```{code-cell} ipython3
 :tags: [remove-cell]
-glue("benign_count", cancer["Class"].value_counts()["Benign"])
-glue("benign_pct", int(np.round(100*cancer["Class"].value_counts(normalize=True)["Benign"])))
-glue("malignant_count", cancer["Class"].value_counts()["Malignant"])
-glue("malignant_pct", int(np.round(100*cancer["Class"].value_counts(normalize=True)["Malignant"])))
+glue("benign_count", "{:0.0f}".format(cancer["Class"].value_counts()["Benign"]))
+glue("benign_pct", "{:0.0f}".format(100*cancer["Class"].value_counts(normalize=True)["Benign"]))
+glue("malignant_count", "{:0.0f}".format(cancer["Class"].value_counts()["Malignant"]))
+glue("malignant_pct", "{:0.0f}".format(100*cancer["Class"].value_counts(normalize=True)["Malignant"]))
 ```
 
 Before we start doing any modeling, let's explore our data set. Below we use
@@ -249,8 +249,8 @@ The total number of observations equals the number of rows in the data frame,
 which we can access via the `shape` attribute of the data frame
 (`shape[0]` is the number of rows and `shape[1]` is the number of columns).
 We have 
-{glue:}`benign_count` ({glue:}`benign_pct`\%) benign and
-{glue:}`malignant_count` ({glue:}`malignant_pct`\%) malignant 
+{glue:text}`benign_count` ({glue:text}`benign_pct`\%) benign and
+{glue:text}`malignant_count` ({glue:text}`malignant_pct`\%) malignant 
 tumor observations.
 
 ```{code-cell} ipython3
@@ -324,8 +324,8 @@ tumor images with unknown diagnoses.
 :tags: [remove-cell]
 
 new_point = [2, 4]
-glue("new_point_1_0", new_point[0])
-glue("new_point_1_1", new_point[1])
+glue("new_point_1_0", "{:.1f}".format(new_point[0]))
+glue("new_point_1_1", "{:.1f}".format(new_point[1]))
 attrs = ["Perimeter", "Concavity"]
 points_df = pd.DataFrame(
     {"Perimeter": new_point[0], "Concavity": new_point[1], "Class": ["Unknown"]}
@@ -354,8 +354,8 @@ $K$ for us. We will cover how to choose $K$ ourselves in the next chapter.
 To illustrate the concept of $K$-nearest neighbors classification, we 
 will walk through an example.  Suppose we have a
 new observation, with standardized perimeter 
-of {glue:}`new_point_1_0` and standardized concavity 
-of {glue:}`new_point_1_1`, whose 
+of {glue:text}`new_point_1_0` and standardized concavity 
+of {glue:text}`new_point_1_1`, whose 
 diagnosis "Class" is unknown. This new observation is 
 depicted by the red, diamond point in {numref}`fig:05-knn-2`.
 
@@ -390,13 +390,13 @@ near_neighbor_df = pd.concat([
     cancer.loc[[np.argmin(my_distances)], attrs],
     perim_concav_with_new_point_df.loc[[cancer.shape[0]], attrs],
 ])
-glue("1-neighbor_per", round(near_neighbor_df.iloc[0, :]["Perimeter"], 1))
-glue("1-neighbor_con", round(near_neighbor_df.iloc[0, :]["Concavity"], 1))
+glue("1-neighbor_per", "{:.1f}".format(near_neighbor_df.iloc[0, :]["Perimeter"]))
+glue("1-neighbor_con", "{:.1f}".format(near_neighbor_df.iloc[0, :]["Concavity"]))
 ```
 
 {numref}`fig:05-knn-3` shows that the nearest point to this new observation is
-**malignant** and located at the coordinates ({glue:}`1-neighbor_per`,
-{glue:}`1-neighbor_con`). The idea here is that if a point is close to another
+**malignant** and located at the coordinates ({glue:text}`1-neighbor_per`,
+{glue:text}`1-neighbor_con`). The idea here is that if a point is close to another
 in the scatter plot, then the perimeter and concavity values are similar, 
 and so we may expect that they would have the same diagnosis.
 
@@ -434,8 +434,8 @@ perim_concav_with_new_point_df2 = pd.concat((cancer, points_df2), ignore_index=T
 my_distances2 = euclidean_distances(perim_concav_with_new_point_df2[attrs])[
     len(cancer)
 ][:-1]
-glue("new_point_2_0", new_point[0])
-glue("new_point_2_1", new_point[1])
+glue("new_point_2_0", "{:.1f}".format(new_point[0]))
+glue("new_point_2_1", "{:.1f}".format(new_point[1]))
 ```
 
 ```{code-cell} ipython3
@@ -471,16 +471,16 @@ line2 = alt.Chart(near_neighbor_df2).mark_line().encode(
     color=alt.value("black")
 )
 
-glue("2-neighbor_per", round(near_neighbor_df2.iloc[0, :]["Perimeter"], 1))
-glue("2-neighbor_con", round(near_neighbor_df2.iloc[0, :]["Concavity"], 1))
+glue("2-neighbor_per", "{:.1f}".format(near_neighbor_df2.iloc[0, :]["Perimeter"]))
+glue("2-neighbor_con", "{:.1f}".format(near_neighbor_df2.iloc[0, :]["Concavity"]))
 glue('fig:05-knn-4', (perim_concav_with_new_point2 + line2), display=True)
 ```
 
 Suppose we have another new observation with standardized perimeter
-{glue:}`new_point_2_0` and concavity of {glue:}`new_point_2_1`. Looking at the
+{glue:text}`new_point_2_0` and concavity of {glue:text}`new_point_2_1`. Looking at the
 scatter plot in {numref}`fig:05-knn-4`, how would you classify this red,
 diamond observation? The nearest neighbor to this new point is a
-**benign** observation at ({glue:}`2-neighbor_per`, {glue:}`2-neighbor_con`).
+**benign** observation at ({glue:text}`2-neighbor_per`, {glue:text}`2-neighbor_con`).
 Does this seem like the right prediction to make for this observation? Probably 
 not, if you consider the other nearby points.
 
@@ -570,8 +570,8 @@ $$\mathrm{Distance} = \sqrt{(a_x -b_x)^2 + (a_y - b_y)^2}$$
 To find the $K$ nearest neighbors to our new observation, we compute the distance
 from that new observation to each observation in our training data, and select the $K$ observations corresponding to the
 $K$ *smallest* distance values. For example, suppose we want to use $K=5$ neighbors to classify a new 
-observation with perimeter of {glue:}`3-new_point_0` and 
-concavity of {glue:}`3-new_point_1`, shown as a red diamond in {numref}`fig:05-multiknn-1`. Let's calculate the distances
+observation with perimeter {glue:text}`3-new_point_0` and 
+concavity {glue:text}`3-new_point_1`, shown as a red diamond in {numref}`fig:05-multiknn-1`. Let's calculate the distances
 between our new point and each of the observations in the training set to find
 the $K=5$ neighbors that are nearest to our new point. 
 You will see in the code below, we compute the straight-line
@@ -611,8 +611,8 @@ perim_concav_with_new_point3 = (
     )
 )
 
-glue("3-new_point_0", new_point[0])
-glue("3-new_point_1", new_point[1])
+glue("3-new_point_0", "{:.1f}".format(new_point[0]))
+glue("3-new_point_1", "{:.1f}".format(new_point[1]))
 glue("fig:05-multiknn-1", perim_concav_with_new_point3)
 ```
 
@@ -1101,8 +1101,8 @@ scaled_cancer
 ```
 ```{code-cell} ipython3
 :tags: [remove-cell]
-glue("scaled-cancer-column-0", scaled_cancer.columns[0])
-glue("scaled-cancer-column-1", scaled_cancer.columns[1])
+glue("scaled-cancer-column-0", '"'+scaled_cancer.columns[0]+'"')
+glue("scaled-cancer-column-1", '"'+scaled_cancer.columns[1]+'"')
 ```
 It looks like our `Smoothness` and `Area` variables have been standardized. Woohoo!
 But there are two important things to notice about the new `scaled_cancer` data frame. First, it only keeps
@@ -1112,8 +1112,8 @@ is to *drop* the remaining columns. This default behavior works well with the re
 in {numref}`08:puttingittogetherworkflow`), but for visualizing the result of preprocessing it can be useful to keep the other columns
 in our original data frame, such as the `Class` variable here.
 To keep other columns, we need to set the `remainder` argument to `"passthrough"` in the `make_column_transformer` function.
-Furthermore, you can see that the new column names---{glue:}`scaled-cancer-column-0`
-and {glue:}`scaled-cancer-column-1`---include the name
+Furthermore, you can see that the new column names---{glue:text}`scaled-cancer-column-0`
+and {glue:text}`scaled-cancer-column-1`---include the name
 of the preprocessing step separated by underscores. This default behavior is useful in `sklearn` because we sometimes want to apply
 multiple different preprocessing steps to the same columns; but again, for visualization it can be useful to preserve
 the original column names. To keep original column names, we need to set the `verbose_feature_names_out` argument to `False`.

--- a/source/classification2.md
+++ b/source/classification2.md
@@ -511,15 +511,15 @@ cancer_test.info()
 ```{code-cell} ipython3
 :tags: [remove-cell]
 
-glue("cancer_train_nrow", len(cancer_train))
-glue("cancer_test_nrow", len(cancer_test))
+glue("cancer_train_nrow", "{:d}".format(len(cancer_train)))
+glue("cancer_test_nrow", "{:d}".format(len(cancer_test)))
 ```
 
 ```{index} info
 ```
 
-We can see from the `info` method above that the training set contains {glue:}`cancer_train_nrow` observations, 
-while the test set contains {glue:}`cancer_test_nrow` observations. This corresponds to
+We can see from the `info` method above that the training set contains {glue:text}`cancer_train_nrow` observations, 
+while the test set contains {glue:text}`cancer_test_nrow` observations. This corresponds to
 a train / test split of 75% / 25%, as desired. Recall from {numref}`Chapter %s <classification1>`
 that we use the `info` method to preview the number of rows, the variable names, their data types, and 
 missing entries of a data frame.
@@ -529,8 +529,8 @@ missing entries of a data frame.
 
 We can use the `value_counts` method with the `normalize` argument set to `True` 
 to find the percentage of malignant and benign classes 
-in `cancer_train`. We see about {glue:}`cancer_train_b_prop`% of the training
-data are benign and {glue:}`cancer_train_m_prop`% 
+in `cancer_train`. We see about {glue:text}`cancer_train_b_prop`% of the training
+data are benign and {glue:text}`cancer_train_m_prop`% 
 are malignant, indicating that our class proportions were roughly preserved when we split the data.
 
 ```{code-cell} ipython3
@@ -540,8 +540,8 @@ cancer_train["Class"].value_counts(normalize=True)
 ```{code-cell} ipython3
 :tags: [remove-cell]
 
-glue("cancer_train_b_prop", round(cancer_train["Class"].value_counts(normalize = True)["Benign"]*100))
-glue("cancer_train_m_prop", round(cancer_train["Class"].value_counts(normalize = True)["Malignant"]*100))
+glue("cancer_train_b_prop", "{:0.0f}".format(cancer_train["Class"].value_counts(normalize = True)["Benign"]*100))
+glue("cancer_train_m_prop", "{:0.0f}".format(cancer_train["Class"].value_counts(normalize = True)["Malignant"]*100))
 ```
 
 ### Preprocess the data
@@ -655,13 +655,13 @@ cancer_acc_1
 ```{code-cell} ipython3
 :tags: [remove-cell]
 
-glue("cancer_acc_1", round(100*cancer_acc_1))
+glue("cancer_acc_1", "{:0.0f}".format(100*cancer_acc_1))
 ```
 
 +++
 
 The output shows that the estimated accuracy of the classifier on the test data 
-was {glue:}`cancer_acc_1`%.
+was {glue:text}`cancer_acc_1`%.
 We can also look at the *confusion matrix* for the classifier 
 using the `crosstab` function from `pandas`. A confusion matrix shows how many 
 observations of each (true) label were classified as each (predicted) label.
@@ -686,25 +686,25 @@ c00 = _ctab["Benign"]["Benign"]
 c10 = _ctab["Benign"]["Malignant"] # classify benign, true malignant 
 c01 = _ctab["Malignant"]["Benign"] # classify malignant, true benign
 
-glue("confu11", c11)
-glue("confu00", c00)
-glue("confu10", c10)
-glue("confu01", c01)
-glue("confu11_00", c11 + c00)
-glue("confu10_11", c10 + c11)
-glue("confu_fal_neg", round(100 * c10 / (c10 + c11)))
-glue("confu_accuracy", np.round(100*(c00+c11)/(c00+c11+c01+c10),2))
-glue("confu_precision", np.round(100*c11/(c11+c01), 2))
-glue("confu_recall", np.round(100*c11/(c11+c10),2))
-glue("confu_precision_0", round(100*c11/(c11+c01)))
-glue("confu_recall_0", round(100*c11/(c11+c10)))
+glue("confu11", "{:d}".format(c11))
+glue("confu00", "{:d}".format(c00))
+glue("confu10", "{:d}".format(c10))
+glue("confu01", "{:d}".format(c01))
+glue("confu11_00", "{:d}".format(c11 + c00))
+glue("confu10_11", "{:d}".format(c10 + c11))
+glue("confu_fal_neg", "{:0.0f}".format(100 * c10 / (c10 + c11)))
+glue("confu_accuracy", "{:.2f}".format(100*(c00+c11)/(c00+c11+c01+c10)))
+glue("confu_precision", "{:.2f}".format(100*c11/(c11+c01)))
+glue("confu_recall", "{:.2f}".format(100*c11/(c11+c10)))
+glue("confu_precision_0", "{:0.0f}".format(100*c11/(c11+c01)))
+glue("confu_recall_0", "{:0.0f}".format(100*c11/(c11+c10)))
 ```
 
-The confusion matrix shows {glue:}`confu11` observations were correctly predicted 
-as malignant, and {glue:}`confu00` were correctly predicted as benign. 
+The confusion matrix shows {glue:text}`confu11` observations were correctly predicted 
+as malignant, and {glue:text}`confu00` were correctly predicted as benign. 
 It also shows that the classifier made some mistakes; in particular,
-it classified {glue:}`confu10` observations as benign when they were truly malignant,
-and {glue:}`confu01` observations as malignant when they were truly benign.
+it classified {glue:text}`confu10` observations as benign when they were truly malignant,
+and {glue:text}`confu01` observations as malignant when they were truly benign.
 Using our formulas from earlier, we see that the accuracy agrees with what Python reported,
 and can also compute the precision and recall of the classifier:
 
@@ -742,9 +742,9 @@ glue("rec_eq_math_glued", rec_eq_math)
 
 ### Critically analyze performance
 
-We now know that the classifier was {glue:}`cancer_acc_1`% accurate
-on the test data set, and had a precision of {glue:}`confu_precision_0`% and 
-a recall of {glue:}`confu_recall_0`%. 
+We now know that the classifier was {glue:text}`cancer_acc_1`% accurate
+on the test data set, and had a precision of {glue:text}`confu_precision_0`% and 
+a recall of {glue:text}`confu_recall_0`%. 
 That sounds pretty good! Wait, *is* it good? 
 Or do we need something higher?
 
@@ -795,16 +795,16 @@ the majority classifier would *always* predict that a new observation
 is benign. The estimated accuracy of the majority classifier is usually
 fairly close to the majority class proportion in the training data.
 In this case, we would suspect that the majority classifier will have 
-an accuracy of around {glue:}`cancer_train_b_prop`%.
+an accuracy of around {glue:text}`cancer_train_b_prop`%.
 The $K$-nearest neighbors classifier we built does quite a bit better than this, 
-with an accuracy of {glue:}`cancer_acc_1`%. 
+with an accuracy of {glue:text}`cancer_acc_1`%. 
 This means that from the perspective of accuracy,
 the $K$-nearest neighbors classifier improved quite a bit on the basic
 majority classifier. Hooray! But we still need to be cautious; in 
 this application, it is likely very important not to misdiagnose any malignant tumors to avoid missing
 patients who actually need medical care. The confusion matrix above shows
 that the classifier does, indeed, misdiagnose a significant number of 
-malignant tumors as benign ({glue:}`confu10` out of {glue:}`confu10_11` malignant tumors, or {glue:}`confu_fal_neg`%!).
+malignant tumors as benign ({glue:text}`confu10` out of {glue:text}`confu10_11` malignant tumors, or {glue:text}`confu_fal_neg`%!).
 Therefore, even though the accuracy improved upon the majority classifier,
 our critical analysis suggests that this classifier may not have appropriate performance
 for the application.
@@ -921,25 +921,23 @@ accuracies = list(np.round(np.array(accuracies)*100, 1))
 
 ```{code-cell} ipython3
 :tags: [remove-cell]
-glue(f"acc_seed1", np.round(100 * acc,1))
-glue("avg_5_splits", avg_accuracy)
-glue("accuracies", accuracies)
+glue("acc_seed1", "{:0.1f}".format(100 * acc))
+glue("avg_5_splits", "{:0.1f}".format(avg_accuracy))
+glue("accuracies", "[" + "%, ".join(["{:0.1f}".format(acc) for acc in accuracies]) + "%]")
 ```
 ```{code-cell} ipython3
 :tags: [remove-cell]
 
 ```
 
-
-
-The accuracy estimate using this split is {glue:}`acc_seed1`%.
+The accuracy estimate using this split is {glue:text}`acc_seed1`%.
 Now we repeat the above code 4 more times, which generates 4 more splits.
 Therefore we get five different shuffles of the data, and therefore five different values for
-accuracy: {glue:}`accuracies` (each a percentage). None of these values are
+accuracy: {glue:text}`accuracies`. None of these values are
 necessarily "more correct" than any other; they're
 just five estimates of the true, underlying accuracy of our classifier built
 using our overall training data. We can combine the estimates by taking their
-average (here {glue:}`avg_5_splits`%) to try to get a single assessment of our
+average (here {glue:text}`avg_5_splits`%) to try to get a single assessment of our
 classifier's accuracy; this has the effect of reducing the influence of any one
 (un)lucky validation set on the estimate. 
 
@@ -1007,9 +1005,9 @@ We can then aggregate the *mean* and *standard error*
 of the classifier's validation accuracy across the folds. 
 You should consider the mean (`mean`) to be the estimated accuracy, while the standard 
 error (`sem`) is a measure of how uncertain we are in that mean value. A detailed treatment of this
-is beyond the scope of this chapter; but roughly, if your estimated mean is {glue:}`cv_5_mean` and standard
-error is {glue:}`cv_5_std`, you can expect the *true* average accuracy of the 
-classifier to be somewhere roughly between {glue:}`cv_5_lower`% and {glue:}`cv_5_upper`% (although it may
+is beyond the scope of this chapter; but roughly, if your estimated mean is {glue:text}`cv_5_mean` and standard
+error is {glue:text}`cv_5_std`, you can expect the *true* average accuracy of the 
+classifier to be somewhere roughly between {glue:text}`cv_5_lower`% and {glue:text}`cv_5_upper`% (although it may
 fall outside this range). You may ignore the other columns in the metrics data frame.
 
 ```{code-cell} ipython3
@@ -1020,27 +1018,25 @@ cv_5_metrics
 ```{code-cell} ipython3
 :tags: [remove-cell]
 
-glue("cv_5_mean", round(cv_5_metrics.loc["mean", "test_score"], 2))
-glue("cv_5_std", round(cv_5_metrics.loc["sem", "test_score"], 2))
-glue(
-    "cv_5_upper",
-    round(
+glue("cv_5_mean", "{:.2f}".format(cv_5_metrics.loc["mean", "test_score"]))
+glue("cv_5_std", "{:.2f}".format(cv_5_metrics.loc["sem", "test_score"]))
+glue("cv_5_upper",
+    "{:0.0f}".format(
         100
         * (
             round(cv_5_metrics.loc["mean", "test_score"], 2)
             + round(cv_5_metrics.loc["sem", "test_score"], 2)
         )
-    ),
+    )
 )
-glue(
-    "cv_5_lower",
-    round(
+glue("cv_5_lower",
+    "{:0.0f}".format(
         100
         * (
             round(cv_5_metrics.loc["mean", "test_score"], 2)
             - round(cv_5_metrics.loc["sem", "test_score"], 2)
         )
-    ),
+    )
 )
 ```
 
@@ -1093,19 +1089,19 @@ cv_50_metrics
 ```{code-cell} ipython3
 :tags: [remove-cell]
 
-glue("cv_10_mean", round(100 * cv_10_metrics.loc["mean", "test_score"]))
+glue("cv_10_mean", "{:0.0f}".format(100 * cv_10_metrics.loc["mean", "test_score"]))
 ```
 
 ### Parameter value selection
 
 Using 5- and 10-fold cross-validation, we have estimated that the prediction
-accuracy of our classifier is somewhere around {glue:}`cv_10_mean`%. 
+accuracy of our classifier is somewhere around {glue:text}`cv_10_mean`%. 
 Whether that is good or not
 depends entirely on the downstream application of the data analysis. In the
 present situation, we are trying to predict a tumor diagnosis, with expensive,
 damaging chemo/radiation therapy or patient death as potential consequences of
 misprediction. Hence, we might like to 
-do better than {glue:}`cv_10_mean`% for this application.  
+do better than {glue:text}`cv_10_mean`% for this application.  
 
 In order to improve our classifier, we have one choice of parameter: the number of
 neighbors, $K$. Since cross-validation helps us evaluate the accuracy of our
@@ -1248,8 +1244,8 @@ accuracy_vs_k
 :tags: [remove-cell]
 
 glue("fig:06-find-k", accuracy_vs_k)
-glue("best_k_unique", accuracies_grid["n_neighbors"][accuracies_grid["mean_test_score"].idxmax()])
-glue("best_acc", np.round(accuracies_grid["mean_test_score"].max()*100,1))
+glue("best_k_unique", "{:d}".format(accuracies_grid["n_neighbors"][accuracies_grid["mean_test_score"].idxmax()]))
+glue("best_acc", "{:.1f}".format(accuracies_grid["mean_test_score"].max()*100))
 ```
 
 :::{glue:figure} fig:06-find-k
@@ -1261,13 +1257,13 @@ Plot of estimated accuracy versus the number of neighbors.
 +++
 
 Setting the number of 
-neighbors to $K =$ {glue:}`best_k_unique`
-provides the highest accuracy ({glue:}`best_acc`%). But there is no exact or perfect answer here;
+neighbors to $K =$ {glue:text}`best_k_unique`
+provides the highest accuracy ({glue:text}`best_acc`%). But there is no exact or perfect answer here;
 any selection from $K = 30$ to $80$ or so would be reasonably justified, as all
 of these differ in classifier accuracy by a small amount. Remember: the
 values you see on this plot are *estimates* of the true accuracy of our
 classifier. Although the 
-$K =$ {glue:}`best_k_unique` value is 
+$K =$ {glue:text}`best_k_unique` value is 
 higher than the others on this plot,
 that doesn't mean the classifier is actually more accurate with this parameter
 value! Generally, when selecting $K$ (and other parameters for other predictive
@@ -1277,12 +1273,12 @@ models), we are looking for a value where:
 - changing the value to a nearby one (e.g., adding or subtracting a small number) doesn't decrease accuracy too much, so that our choice is reliable in the presence of uncertainty;
 - the cost of training the model is not prohibitive (e.g., in our situation, if $K$ is too large, predicting becomes expensive!).
 
-We know that $K =$ {glue:}`best_k_unique` 
+We know that $K =$ {glue:text}`best_k_unique` 
 provides the highest estimated accuracy. Further, {numref}`fig:06-find-k` shows that the estimated accuracy 
-changes by only a small amount if we increase or decrease $K$ near $K =$ {glue:}`best_k_unique`.
-And finally, $K =$ {glue:}`best_k_unique` does not create a prohibitively expensive
+changes by only a small amount if we increase or decrease $K$ near $K =$ {glue:text}`best_k_unique`.
+And finally, $K =$ {glue:text}`best_k_unique` does not create a prohibitively expensive
 computational cost of training. Considering these three points, we would indeed select
-$K =$ {glue:}`best_k_unique` for the classifier.
+$K =$ {glue:text}`best_k_unique` for the classifier.
 
 +++
 
@@ -1700,12 +1696,12 @@ Effect of inclusion of irrelevant predictors.
 ```{code-cell} ipython3
 :tags: [remove-cell]
 
-glue("cancer_propn_1", round(cancer_proportions.loc["Benign", "percent"]))
+glue("cancer_propn_1", "{:0.0f}".format(cancer_proportions.loc["Benign", "percent"]))
 ```
 
 Although the accuracy decreases as expected, one surprising thing about 
 {numref}`fig:06-performance-irrelevant-features` is that it shows that the method
-still outperforms the baseline majority classifier (with about {glue:}`cancer_propn_1`% accuracy) 
+still outperforms the baseline majority classifier (with about {glue:text}`cancer_propn_1`% accuracy) 
 even with 40 irrelevant variables.
 How could that be? {numref}`fig:06-neighbors-irrelevant-features` provides the answer:
 the tuning procedure for the $K$-nearest neighbors classifier combats the extra randomness from the irrelevant variables 
@@ -1937,11 +1933,11 @@ cancer_pipe_forward.named_steps["sequentialfeatureselector"].n_features_to_selec
 
 glue(
     "sequentialfeatureselector_n_features",
-    cancer_pipe_forward.named_steps["sequentialfeatureselector"].n_features_to_select_,
+    "{:d}".format(cancer_pipe_forward.named_steps["sequentialfeatureselector"].n_features_to_select_),
 )
 ```
 
-This means that {glue:}`sequentialfeatureselector_n_features` features were selected according to the forward selection algorithm.
+This means that {glue:text}`sequentialfeatureselector_n_features` features were selected according to the forward selection algorithm.
 
 +++
 

--- a/source/clustering.md
+++ b/source/clustering.md
@@ -324,13 +324,13 @@ clus_rows = clus.shape[0]
 mean_flipper_len_std = round(np.mean(clus["flipper_length_standardized"]),2)
 mean_bill_len_std = round(np.mean(clus["bill_length_standardized"]),2)
 
-glue("clus_rows_glue", clus_rows)
-glue("mean_flipper_len_std_glue",mean_flipper_len_std)
-glue("mean_bill_len_std_glue", mean_bill_len_std)
+glue("clus_rows_glue", "{:d}".format(clus_rows))
+glue("mean_flipper_len_std_glue","{:.2f}".format(mean_flipper_len_std))
+glue("mean_bill_len_std_glue", "{:.2f}".format(mean_bill_len_std))
 ```
 
-In the first cluster from the example, there are {glue:}`clus_rows_glue` data points. These are shown with their cluster center
-(flipper_length_standardized = {glue:}`mean_flipper_len_std_glue` and bill_length_standardized = {glue:}`mean_bill_len_std_glue`) highlighted
+In the first cluster from the example, there are {glue:text}`clus_rows_glue` data points. These are shown with their cluster center
+(flipper_length_standardized = {glue:text}`mean_flipper_len_std_glue` and bill_length_standardized = {glue:text}`mean_bill_len_std_glue`) highlighted
 in {numref}`toy-example-clus1-center-1`.
 
 
@@ -350,7 +350,7 @@ between each point in the cluster
 and the cluster center.
 We use the straight-line / Euclidean distance formula
 that we learned about in {numref}`Chapter %s <classification1>`.
-In the {glue:}`clus_rows_glue`-observation cluster example above,
+In the {glue:text}`clus_rows_glue`-observation cluster example above,
 we would compute the WSSD $S^2$ via
 
 

--- a/source/inference.md
+++ b/source/inference.md
@@ -178,12 +178,12 @@ airbnb["room_type"].value_counts(normalize=True)
 ```{code-cell} ipython3
 :tags: [remove-cell]
 
-glue("population_proportion", airbnb["room_type"].value_counts(normalize=True)["Entire home/apt"].round(3))
+glue("population_proportion", "{:.3f}".format(airbnb["room_type"].value_counts(normalize=True)["Entire home/apt"]))
 ```
 
 We can see that the proportion of `Entire home/apt` listings in
-the data set is {glue:}`population_proportion`. This
-value, {glue:}`population_proportion`, is the population parameter. Remember, this
+the data set is {glue:text}`population_proportion`. This
+value, {glue:text}`population_proportion`, is the population parameter. Remember, this
 parameter value is usually unknown in real data analysis problems, as it is
 typically not possible to make measurements for an entire population.
 
@@ -210,11 +210,11 @@ airbnb.sample(n=40)["room_type"].value_counts(normalize=True)
 ```{code-cell} ipython3
 :tags: [remove-cell]
 
-glue("sample_1_proportion", airbnb.sample(n=40, random_state=155)["room_type"].value_counts(normalize=True)["Entire home/apt"].round(3))
+glue("sample_1_proportion", "{:.3f}".format(airbnb.sample(n=40, random_state=155)["room_type"].value_counts(normalize=True)["Entire home/apt"]))
 ```
 
 Here we see that the proportion of entire home/apartment listings in this
-random sample is {glue:}`sample_1_proportion`. Wow&mdash;that's close to our
+random sample is {glue:text}`sample_1_proportion`. Wow&mdash;that's close to our
 true population value! But remember, we computed the proportion using a random sample of size 40.
 This has two consequences. First, this value is only an *estimate*, i.e., our best guess
 of our population parameter using this sample.
@@ -369,9 +369,9 @@ Sampling distribution of the sample proportion for sample size 40.
 ```{code-cell} ipython3
 :tags: [remove-cell]
 
-glue("sample_proportion_center", round(sample_estimates["sample_proportion"].mean(), 2))
-glue("sample_proportion_min", round(sample_estimates["sample_proportion"].quantile(0.004), 2))
-glue("sample_proportion_max", round(sample_estimates["sample_proportion"].quantile(0.9997), 2))
+glue("sample_proportion_center", "{:.2f}".format(sample_estimates["sample_proportion"].mean()))
+glue("sample_proportion_min", "{:.2f}".format(sample_estimates["sample_proportion"].quantile(0.004)))
+glue("sample_proportion_max", "{:.2f}".format(sample_estimates["sample_proportion"].quantile(0.9997)))
 ```
 
 ```{index} sampling distribution; shape
@@ -379,9 +379,9 @@ glue("sample_proportion_max", round(sample_estimates["sample_proportion"].quanti
 
 The sampling distribution in {numref}`fig:11-example-proportions7` appears
 to be bell-shaped, is roughly symmetric, and has one peak. It is centered
-around {glue:}`sample_proportion_center` and the sample proportions
-range from about {glue:}`sample_proportion_min` to about
-{glue:}`sample_proportion_max`. In fact, we can
+around {glue:text}`sample_proportion_center` and the sample proportions
+range from about {glue:text}`sample_proportion_min` to about
+{glue:text}`sample_proportion_max`. In fact, we can
 calculate the mean of the sample proportions.
 
 ```{code-cell} ipython3
@@ -391,11 +391,11 @@ sample_estimates["sample_proportion"].mean()
 ```{code-cell} ipython3
 :tags: [remove-cell]
 
-glue("sample_proportion_mean", round(sample_estimates["sample_proportion"].mean(), 3))
+glue("sample_proportion_mean", "{:.3f}".format(sample_estimates["sample_proportion"].mean()))
 ```
 
 We notice that the sample proportions are centered around the population
-proportion value, {glue:}`sample_proportion_mean`! In general, the mean of
+proportion value, {glue:text}`sample_proportion_mean`! In general, the mean of
 the sampling distribution should be equal to the population proportion.
 This is great news because it means that the sample proportion is neither an overestimate nor an
 underestimate of the population proportion.
@@ -463,14 +463,14 @@ airbnb["price"].mean()
 ```{code-cell} ipython3
 :tags: [remove-cell]
 
-glue("population_mean", airbnb["price"].mean().round(2))
+glue("population_mean", "{:.2f}".format(airbnb["price"].mean()))
 ```
 
 ```{index} population; parameter
 ```
 
 The price per night of all Airbnb rentals in Vancouver, BC
-is \${glue:}`population_mean`, on average. This value is our
+is \${glue:text}`population_mean`, on average. This value is our
 population parameter since we are calculating it using the population data.
 
 ```{index} pandas.DataFrame; sample
@@ -524,17 +524,17 @@ one_sample["price"].mean()
 ```{code-cell} ipython3
 :tags: [remove-cell]
 
-glue("estimate_mean", one_sample["price"].mean().round(2))
-glue("diff_perc", round(100 * abs(1 - (one_sample["price"].mean() / airbnb["price"].mean())), 1))
+glue("estimate_mean", "{:.2f}".format(one_sample["price"].mean()))
+glue("diff_perc", "{:.1f}".format(100 * abs(1 - (one_sample["price"].mean() / airbnb["price"].mean()))))
 ```
 
 The average value of the sample of size 40
-is \${glue:}`estimate_mean`.  This
+is \${glue:text}`estimate_mean`.  This
 number is a point estimate for the mean of the full population.
 Recall that the population mean was
-\${glue:}`population_mean`. So our estimate was fairly close to
+\${glue:text}`population_mean`. So our estimate was fairly close to
 the population parameter: the mean was about
-{glue:}`diff_perc`%
+{glue:text}`diff_perc`%
 off.  Note that we usually cannot compute the estimate's accuracy in practice
 since we do not have access to the population parameter; if we did, we wouldn't
 need to estimate it!
@@ -594,8 +594,8 @@ Sampling distribution of the sample means for sample size of 40.
 ```{code-cell} ipython3
 :tags: [remove-cell]
 
-glue("quantile_1", round(int(sample_estimates["mean_price"].quantile(0.25)), - 1))
-glue("quantile_3", round(int(sample_estimates["mean_price"].quantile(0.75)), - 1))
+glue("quantile_1", "{:0.0f}".format(round(sample_estimates["mean_price"].quantile(0.25), -1)))
+glue("quantile_3", "{:0.0f}".format(round(sample_estimates["mean_price"].quantile(0.75), -1)))
 ```
 
 ```{index} sampling distribution; shape
@@ -603,12 +603,12 @@ glue("quantile_3", round(int(sample_estimates["mean_price"].quantile(0.75)), - 1
 
 In {numref}`fig:11-example-means4`, the sampling distribution of the mean
 has one peak and is bell-shaped. Most of the estimates are between
-about  \${glue:}`quantile_1` and
-\${glue:}`quantile_3`; but there are
+about  \${glue:text}`quantile_1` and
+\${glue:text}`quantile_3`; but there are
 a good fraction of cases outside this range (i.e., where the point estimate was
 not close to the population parameter). So it does indeed look like we were
 quite lucky when we estimated the population mean with only
-{glue:}`diff_perc`% error.
+{glue:text}`diff_perc`% error.
 
 ```{index} sampling distribution; compared to population distribution
 ```
@@ -944,7 +944,7 @@ and use a bootstrap distribution using just a single sample from the population.
 Once again, suppose we are
 interested in estimating the population mean price per night of all Airbnb
 listings in Vancouver, Canada, using a single sample size of 40.
-Recall our point estimate was \${glue:}`estimate_mean`. The
+Recall our point estimate was \${glue:text}`estimate_mean`. The
 histogram of prices in the sample is displayed in {numref}`fig:11-bootstrapping1`.
 
 ```{code-cell} ipython3
@@ -974,7 +974,7 @@ Histogram of price per night (dollars) for one sample of size 40.
 +++
 
 The histogram for the sample is skewed, with a few observations out to the right. The
-mean of the sample is \${glue:}`estimate_mean`.
+mean of the sample is \${glue:text}`estimate_mean`.
 Remember, in practice, we usually only have this one sample from the population. So
 this sample and estimate are the only data we can work with.
 
@@ -1171,7 +1171,7 @@ Comparison of the distribution of the bootstrap sample means and sampling distri
 ```{code-cell} ipython3
 :tags: [remove-cell]
 
-glue("one_sample_mean", round(one_sample["price"].mean(), 2))
+glue("one_sample_mean", "{:.2f}".format(one_sample["price"].mean()))
 ```
 
 ```{index} sampling distribution; compared to bootstrap distribution
@@ -1183,9 +1183,9 @@ distribution and the bootstrap distribution are similar; the bootstrap
 distribution lets us get a sense of the point estimate's variability. The
 second important point is that the means of these two distributions are
 slightly different. The sampling distribution is centered at
-\${glue:}`population_mean`, the population mean value. However, the bootstrap
+\${glue:text}`population_mean`, the population mean value. However, the bootstrap
 distribution is centered at the original sample's mean price per night,
-\${glue:}`one_sample_mean`. Because we are resampling from the
+\${glue:text}`one_sample_mean`. Because we are resampling from the
 original sample repeatedly, we see that the bootstrap distribution is centered
 at the original sample's mean value (unlike the sampling distribution of the
 sample mean, which is centered at the population parameter value).
@@ -1257,11 +1257,11 @@ ci_bounds
 ```{code-cell} ipython3
 :tags: [remove-cell]
 
-glue("ci_lower", round(ci_bounds[0.025], 1))
-glue("ci_upper", round(ci_bounds[0.975], 1))
+glue("ci_lower", "{:.1f}".format(ci_bounds[0.025]))
+glue("ci_upper", "{:.1f}".format(ci_bounds[0.975]))
 ```
 
-Our interval, \${glue:}`ci_lower` to \${glue:}`ci_upper`, captures
+Our interval, \${glue:text}`ci_lower` to \${glue:text}`ci_upper`, captures
 the middle 95\% of the sample mean prices in the bootstrap distribution. We can
 visualize the interval on our distribution in {numref}`fig:11-bootstrapping9`.
 
@@ -1304,11 +1304,11 @@ Distribution of the bootstrap sample means with percentile lower and upper bound
 To finish our estimation of the population parameter, we would report the point
 estimate and our confidence interval's lower and upper bounds. Here the sample
 mean price-per-night of 40 Airbnb listings was
-\${glue:}`one_sample_mean`, and we are 95\% "confident" that the true
+\${glue:text}`one_sample_mean`, and we are 95\% "confident" that the true
 population mean price-per-night for all Airbnb listings in Vancouver is between
-\$({glue:}`ci_lower`, {glue:}`ci_upper`).
+\$({glue:text}`ci_lower`, {glue:text}`ci_upper`).
 Notice that our interval does indeed contain the true
-population mean value, \${glue:}`population_mean`\! However, in
+population mean value, \${glue:text}`population_mean`\! However, in
 practice, we would not know whether our interval captured the population
 parameter or not because we usually only have a single sample, not the entire
 population. This is the best we can do when we only have one sample!

--- a/source/regression1.md
+++ b/source/regression1.md
@@ -648,14 +648,14 @@ may fall outside this range).
 
 {numref}`fig:07-choose-k-knn-plot` visualizes how the RMSPE varies with the number of neighbors $K$.
 We take the *minimum* RMSPE to find the best setting for the number of neighbors.
-The smallest RMSPE occurs when $K$ is {glue:}`best_k_sacr`.
+The smallest RMSPE occurs when $K$ is {glue:text}`best_k_sacr`.
 
 ```{code-cell} ipython3
 :tags: [remove-cell]
 best_k_sacr = sacr_results["n_neighbors"][sacr_results["mean_test_score"].idxmin()]
 best_cv_RMSPE = min(sacr_results["mean_test_score"])
-glue("best_k_sacr", best_k_sacr)
-glue("cv_RMSPE", "{0:,.0f}".format(int(best_cv_RMSPE)))
+glue("best_k_sacr", "{:d}".format(best_k_sacr))
+glue("cv_RMSPE", "{0:,.0f}".format(best_cv_RMSPE))
 ```
 
 ```{code-cell} ipython3
@@ -699,7 +699,7 @@ to be too small or too large, we cause the RMSPE to increase, as shown in
 
 {numref}`fig:07-howK` visualizes the effect of different settings of $K$ on the
 regression model. Each plot shows the predicted values for house sale price from
-our KNN regression model for 6 different values for $K$: 1, 3, {glue:}`best_k_sacr`, 41, 250, and 699 (i.e., all of the training data).
+our KNN regression model for 6 different values for $K$: 1, 3, {glue:text}`best_k_sacr`, 41, 250, and 699 (i.e., all of the training data).
 For each model, we predict prices for the range of possible home sizes we
 observed in the data set (here 500 to 5,000 square feet) and we plot the
 predicted prices as a orange line.
@@ -807,7 +807,7 @@ we would like a model that (1) follows the overall "trend" in the training data,
 actually uses the training data to learn something useful, and (2) does not follow
 the noisy fluctuations, so that we can be confident that our model will transfer/generalize
 well to other new data. If we explore
-the other values for $K$, in particular $K$ = {glue:}`best_k_sacr` (as suggested by cross-validation),
+the other values for $K$, in particular $K$ = {glue:text}`best_k_sacr` (as suggested by cross-validation),
 we can see it achieves this goal: it follows the increasing trend of house price
 versus house size, but is not influenced too much by the idiosyncratic variations
 in price. All of this is similar to how
@@ -818,7 +818,7 @@ chapter.
 
 To assess how well our model might do at predicting on unseen data, we will
 assess its RMSPE on the test data. To do this, we first need to retrain the 
-KNN regression model on the entire training data set using $K =$ {glue:}`best_k_sacr`
+KNN regression model on the entire training data set using $K =$ {glue:text}`best_k_sacr`
 neighbors. Fortunately we do not have to do this ourselves manually; `scikit-learn`
 does it for us automatically. To make predictions with the best model on the test data,
 we can use the `predict` method of the fit `GridSearchCV` object.
@@ -845,7 +845,7 @@ RMSPE
 ```{code-cell} ipython3
 :tags: [remove-cell]
 
-glue("test_RMSPE", "{0:,.0f}".format(int(RMSPE)))
+glue("test_RMSPE", "{0:,.0f}".format(RMSPE))
 ```
 
 Our final model's test error as assessed by RMSPE
@@ -1047,17 +1047,17 @@ sacr_results[
 
 best_k_sacr_multi = sacr_results["n_neighbors"][sacr_results["mean_test_score"].idxmin()]
 min_rmspe_sacr_multi = min(sacr_results["mean_test_score"])
-glue("best_k_sacr_multi", best_k_sacr_multi)
-glue("cv_RMSPE_2pred", "{0:,.0f}".format(int(min_rmspe_sacr_multi)))
+glue("best_k_sacr_multi", "{:d}".format(best_k_sacr_multi))
+glue("cv_RMSPE_2pred", "{0:,.0f}".format(min_rmspe_sacr_multi))
 ```
 
-Here we see that the smallest estimated RMSPE from cross-validation occurs when $K =$ {glue:}`best_k_sacr_multi`.
+Here we see that the smallest estimated RMSPE from cross-validation occurs when $K =$ {glue:text}`best_k_sacr_multi`.
 If we want to compare this multivariable KNN regression model to the model with only a single
 predictor *as part of the model tuning process* (e.g., if we are running forward selection as described
 in the chapter on evaluating and tuning classification models),
 then we must compare the accuracy estimated using only the training data via cross-validation.
 Looking back, the estimated cross-validation accuracy for the single-predictor
-model was {glue:}`cv_RMSPE`.
+model was {glue:text}`cv_RMSPE`.
 The estimated cross-validation accuracy for the multivariable model is
 {glue:text}`cv_RMSPE_2pred`.
 Thus in this case, we did not improve the model

--- a/source/regression2.md
+++ b/source/regression2.md
@@ -399,8 +399,8 @@ pd.DataFrame({"slope": [lm.coef_[0]], "intercept": [lm.intercept_]})
 ```{code-cell} ipython3
 :tags: [remove-cell]
 
-glue("train_lm_slope", round(lm.coef_[0]))
-glue("train_lm_intercept", round(lm.intercept_))
+glue("train_lm_slope", "{:0.0f}".format(lm.coef_[0]))
+glue("train_lm_intercept", "{:0.0f}".format(lm.intercept_))
 glue("train_lm_slope_f", "{0:,.0f}".format(lm.coef_[0]))
 glue("train_lm_intercept_f", "{0:,.0f}".format(lm.intercept_))
 ```
@@ -422,11 +422,11 @@ the best fit coefficients are usually easier to interpret afterward.
 +++
 
 Our coefficients are
-(intercept) $\beta_0=$ {glue:}`train_lm_intercept`
-and (slope) $\beta_1=$ {glue:}`train_lm_slope`.
+(intercept) $\beta_0=$ {glue:text}`train_lm_intercept`
+and (slope) $\beta_1=$ {glue:text}`train_lm_slope`.
 This means that the equation of the line of best fit is
 
-$\text{house sale price} =$ {glue:}`train_lm_intercept` $+$ {glue:}`train_lm_slope` $\cdot (\text{house size}).$
+$\text{house sale price} =$ {glue:text}`train_lm_intercept` $+$ {glue:text}`train_lm_slope` $\cdot (\text{house size}).$
 
 In other words, the model predicts that houses
 start at \${glue:text}`train_lm_intercept_f` for 0 square feet, and that

--- a/source/viz.md
+++ b/source/viz.md
@@ -695,8 +695,8 @@ numlang_speakers_min = int(min(can_lang["mother_tongue"]))
 print(numlang_speakers_min)
 log_result = int(np.floor(np.log10(numlang_speakers_max/numlang_speakers_min)))
 print(log_result)
-glue("numlang_speakers_max", numlang_speakers_max)
-glue("numlang_speakers_min", numlang_speakers_min)
+glue("numlang_speakers_max", "{0:,.0f}".format(numlang_speakers_max))
+glue("numlang_speakers_min", "{0:,.0f}".format(numlang_speakers_min))
 glue("log_result", log_result)
 ```
 
@@ -707,8 +707,8 @@ up in the lower left-hand side of the visualization. The data is clumped because
 many more people in Canada speak English or French (the two points in
 the upper right corner) than other languages.
 In particular, the most common mother tongue language
-has {glue:}`numlang_speakers_max` speakers,
-while the least common has only {glue:}`numlang_speakers_min`.
+has {glue:text}`numlang_speakers_max` speakers,
+while the least common has only {glue:text}`numlang_speakers_min`.
 That's a six-decimal-place difference
 in the magnitude of these two numbers!
 We can confirm that the two points in the upper right-hand corner correspond
@@ -813,9 +813,9 @@ Scatter plot of number of Canadians reporting a language as their mother tongue 
 english_mother_tongue = can_lang.loc[can_lang["language"]=="English"].mother_tongue.values[0]
 census_popn = int(35151728)
 result = round((english_mother_tongue/census_popn)*100,2)
-glue("english_mother_tongue", english_mother_tongue)
-glue("census_popn", census_popn)
-glue("result", result)
+glue("english_mother_tongue", "{0:,.0f}".format(english_mother_tongue))
+glue("census_popn", "{0:,.0f}".format(census_popn))
+glue("result", "{:.2f}".format(result))
 
 ```
 
@@ -828,8 +828,8 @@ by the number of people who live in Canada and multiplying by 100\%.
 For example,
 the percentage of people who reported that their mother tongue was English
 in the 2016 Canadian census
-was {glue:}`english_mother_tongue` / {glue:}`census_popn` $\times$
-`100` \% = {glue:}`result`\%
+was {glue:text}`english_mother_tongue` / {glue:text}`census_popn` $\times$
+100\% = {glue:text}`result`\%
 
 Below we use `assign` to calculate the percentage of people reporting a given
 language as their mother tongue and primary language at home for all the
@@ -1971,8 +1971,8 @@ import numpy as np
 png_size = np.round(os.path.getsize("img/viz/faithful_plot.png")/(1024*1024), 2)
 svg_size = np.round(os.path.getsize("img/viz/faithful_plot.svg")/(1024*1024), 2)
 
-glue("png_size", png_size)
-glue("svg_size", svg_size)
+glue("png_size", "{:.2f}".format(png_size))
+glue("svg_size", "{:.2f}".format(svg_size))
 ```
 
 ```{list-table} File sizes of the scatter plot of the Old Faithful data set when saved as different file formats.
@@ -1984,10 +1984,10 @@ glue("svg_size", svg_size)
   - Image size
 * - Raster
   - PNG
-  - {glue:}`png_size` MB
+  - {glue:text}`png_size` MB
 * - Vector
   - SVG
-  - {glue:}`svg_size` MB
+  - {glue:text}`svg_size` MB
 ```
 
 Take a look at the file sizes in {numref}`png-vs-svg-table`.


### PR DESCRIPTION
Closes #132 

The fix is to use `{glue:text}` everywhere, and change the css to avoid the bolding that JBook does by default.