### PR TITLE
Update to altair 5.1.2 to fix histrogram chart

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,5 +47,6 @@ ENV PYDEVD_DISABLE_FILE_VALIDATION=1
 #        'nodejs' \
 #    && mamba clean --all -f -y \
 #    && fix-permissions "${CONDA_DIR}" \
-#    && fix-permissions "/home/${NB_USER}" 
+#    && fix-permissions "/home/${NB_USER}"
+#
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,5 +48,4 @@ ENV PYDEVD_DISABLE_FILE_VALIDATION=1
 #    && mamba clean --all -f -y \
 #    && fix-permissions "${CONDA_DIR}" \
 #    && fix-permissions "/home/${NB_USER}"
-#
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN pip install docutils==0.17.1 # Need to pin docutils to an old version for no
 RUN pip install referencing
 RUN pip install jupyter-book
 # Pinning pandas until altair 5.1.2 to avoid future warning https://github.com/altair-viz/altair/issues/3181
-RUN pip install numpy jinja2 pandas"<2.1" altair">=5.1.1" "vegafusion[embed]" vl-convert-python">=0.13" click ibis-framework ghp-import jupytext nodejs lxml
+RUN pip install numpy jinja2 pandas altair">=5.1.2" "vegafusion[embed]" vl-convert-python">=0.14" click ibis-framework ghp-import jupytext nodejs lxml
 
 # forces scikit-learn to grab latest to avoid bug in 1.3.0 related to checking for c-contiguity breaking figures in classification 2. See https://github.com/scikit-learn/scikit-learn/pull/26772
 # TODO: remove this once scikit-learn 1.4.x or beyond releases and is incorporated into jupyter/scipy-notebook

--- a/build_html.sh
+++ b/build_html.sh
@@ -1,2 +1,2 @@
 chmod -R o+w source/
-docker run --rm -v $(pwd):/home/jovyan ubcdsci/py-intro-to-ds:20231108190825ac6d61 /bin/bash -c "jupyter-book build source"
+docker run --rm -v $(pwd):/home/jovyan ubcdsci/py-intro-to-ds:20231108192908c9b484 /bin/bash -c "jupyter-book build source"

--- a/build_html.sh
+++ b/build_html.sh
@@ -1,2 +1,2 @@
 chmod -R o+w source/
-docker run --rm -v $(pwd):/home/jovyan ubcdsci/py-intro-to-ds:20230923214301d47351 /bin/bash -c "jupyter-book build source"
+docker run --rm -v $(pwd):/home/jovyan ubcdsci/py-intro-to-ds:20231108190825ac6d61 /bin/bash -c "jupyter-book build source"

--- a/build_pdf.sh
+++ b/build_pdf.sh
@@ -1,2 +1,2 @@
 chmod -R o+w source/
-docker run --rm -v $(pwd):/home/jovyan ubcdsci/py-intro-to-ds:20230923214301d47351 /bin/bash -c "export BOOK_BUILD_TYPE='PDF'; jupyter-book build source --builder pdflatex"
+docker run --rm -v $(pwd):/home/jovyan ubcdsci/py-intro-to-ds:20231108190825ac6d61 /bin/bash -c "export BOOK_BUILD_TYPE='PDF'; jupyter-book build source --builder pdflatex"

--- a/build_pdf.sh
+++ b/build_pdf.sh
@@ -1,2 +1,2 @@
 chmod -R o+w source/
-docker run --rm -v $(pwd):/home/jovyan ubcdsci/py-intro-to-ds:20231108190825ac6d61 /bin/bash -c "export BOOK_BUILD_TYPE='PDF'; jupyter-book build source --builder pdflatex"
+docker run --rm -v $(pwd):/home/jovyan ubcdsci/py-intro-to-ds:20231108192908c9b484 /bin/bash -c "export BOOK_BUILD_TYPE='PDF'; jupyter-book build source --builder pdflatex"


### PR DESCRIPTION
The chart above the "[Choosing a binwidth" heading](https://python.datasciencebook.ca/viz.html#choosing-a-binwidth-for-histograms) is not showing up correctly (the histograms are missing). I am not sure what the exact issue is but upgrading altair in the docker image and rebuilding fixed it for me locally, so I'm suggesting we do that.

Oddly enough this issue does not show up in jupyter lab, just when building the charts via jupyter book.

Current:
![image](https://github.com/UBC-DSCI/introduction-to-datascience-python/assets/4560057/0c1c92e9-ad28-4907-a391-95b712d9c10f)

After fix (the figure number is different because I didnt' build the entire book locally to save time):
![image](https://github.com/UBC-DSCI/introduction-to-datascience-python/assets/4560057/211958f9-34b5-4317-8e74-5b2d453d7daf)
