### PR TITLE
Switch back to conda install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,39 +13,30 @@ WORKDIR "${HOME}"
 # remove the "work/" directory added in an earlier layer...
 RUN rm -rf work
 
-
-RUN pip install docutils==0.17.1 # Need to pin docutils to an old version for now, due to https://github.com/executablebooks/jupyter-book/issues/2022
-RUN pip install referencing
-RUN pip install jupyter-book
-# Pinning pandas until altair 5.1.2 to avoid future warning https://github.com/altair-viz/altair/issues/3181
-RUN pip install numpy jinja2 pandas altair">=5.1.2" "vegafusion[embed]" vl-convert-python">=0.14" click ibis-framework ghp-import jupytext nodejs lxml
-
-# forces scikit-learn to grab latest to avoid bug in 1.3.0 related to checking for c-contiguity breaking figures in classification 2. See https://github.com/scikit-learn/scikit-learn/pull/26772
-# TODO: remove this once scikit-learn 1.4.x or beyond releases and is incorporated into jupyter/scipy-notebook
-RUN pip install -U git+https://github.com/scikit-learn/scikit-learn.git@main
-
-# install plotly for 3d figures
-RUN pip install plotly
-
 # disable warnings that pollute build logs; seems to be related to the update to python 3.11
 # https://discourse.jupyter.org/t/debugger-warning-it-seems-that-frozen-modules-are-being-used-python-3-11-0/16544/12
 ENV PYDEVD_DISABLE_FILE_VALIDATION=1
 
 ## Install various python packages
-# commented out for now due to various package version conflicts
-# installing via pip instead above
-#RUN mamba install --quiet --yes \
-#        'numpy' \
-#        'jinja2' \
-#        'altair_data_server' \
-#        'altair_saver' \
-#        'click' \
-#        'ibis-framework' \
-#        'ghp-import' \
-#        'jupytext' \
-#        'jupyter-book' \
-#        'nodejs' \
-#    && mamba clean --all -f -y \
-#    && fix-permissions "${CONDA_DIR}" \
-#    && fix-permissions "/home/${NB_USER}"
+RUN mamba install --quiet --yes \
+        'numpy' \
+        'pandas>=2.1.3' \
+        'jinja2' \
+        'altair>=5.1.2' \
+        'vl-convert-python>=0.14' \
+        'vegafusion[embed]' \
+        'click' \
+        'ibis-framework' \
+        'ghp-import' \
+        'jupytext' \
+        'jupyter-book' \
+        'scikit-learn>=1.3.2' \
+        'nodejs' \
+        'plotly' \
+        'lxml' \
+        'referencing' \
+        'docutils==0.17.1' \
+    && mamba clean --all -f -y \
+    && fix-permissions "${CONDA_DIR}" \
+    && fix-permissions "/home/${NB_USER}"
 


### PR DESCRIPTION
Closes #170 

now that the unresolvable build error due to `sphinx-external-toc`'s buggy conda package dependencies has been resolved, this PR switches the dockerfile back to conda-based builds.