### PR TITLE
Handling assign, apply, and lambdas

### DIFF
--- a/source/classification1.md
+++ b/source/classification1.md
@@ -628,15 +628,13 @@ Scatter plot of concavity versus perimeter with new observation represented as a
 ```{code-cell} ipython3
 new_obs_Perimeter = 0
 new_obs_Concavity = 3.5
-(
-    cancer
-   [["Perimeter", "Concavity", "Class"]]
-   .assign(dist_from_new = (
+cancer["dist_from_new"] = (
        (cancer["Perimeter"] - new_obs_Perimeter) ** 2
      + (cancer["Concavity"] - new_obs_Concavity) ** 2
-   )**(1/2))
-   .nsmallest(5, "dist_from_new")
-)
+)**(1/2)
+cancer.nsmallest(5, "dist_from_new")[
+	["Perimeter", "Concavity", "Class", "dist_from_new"]
+]
 ```
 
 ```{code-cell} ipython3
@@ -751,16 +749,14 @@ three predictors.
 new_obs_Perimeter = 0
 new_obs_Concavity = 3.5
 new_obs_Symmetry = 1
-(
-    cancer
-    [["Perimeter", "Concavity", "Symmetry", "Class"]]
-    .assign(dist_from_new = (
-        (cancer["Perimeter"] - new_obs_Perimeter) ** 2
-        + (cancer["Concavity"] - new_obs_Concavity) ** 2
-        + (cancer["Symmetry"] - new_obs_Symmetry) ** 2
-    )**(1/2))
-    .nsmallest(5, "dist_from_new")
-)
+cancer["dist_from_new"] = (
+      (cancer["Perimeter"] - new_obs_Perimeter) ** 2
+    + (cancer["Concavity"] - new_obs_Concavity) ** 2
+    + (cancer["Symmetry"] - new_obs_Symmetry) ** 2
+)**(1/2)
+cancer.nsmallest(5, "dist_from_new")[
+    ["Perimeter", "Concavity", "Symmetry", "Class", "dist_from_new"]
+]
 ```
 
 Based on $K=5$ nearest neighbors with these three predictors we would classify 

--- a/source/classification1.md
+++ b/source/classification1.md
@@ -632,9 +632,12 @@ cancer["dist_from_new"] = (
        (cancer["Perimeter"] - new_obs_Perimeter) ** 2
      + (cancer["Concavity"] - new_obs_Concavity) ** 2
 )**(1/2)
-cancer.nsmallest(5, "dist_from_new")[
-	["Perimeter", "Concavity", "Class", "dist_from_new"]
-]
+cancer.nsmallest(5, "dist_from_new")[[
+	"Perimeter", 
+	"Concavity", 
+	"Class", 
+	"dist_from_new"
+]]
 ```
 
 ```{code-cell} ipython3
@@ -754,9 +757,13 @@ cancer["dist_from_new"] = (
     + (cancer["Concavity"] - new_obs_Concavity) ** 2
     + (cancer["Symmetry"] - new_obs_Symmetry) ** 2
 )**(1/2)
-cancer.nsmallest(5, "dist_from_new")[
-    ["Perimeter", "Concavity", "Symmetry", "Class", "dist_from_new"]
-]
+cancer.nsmallest(5, "dist_from_new")[[
+    "Perimeter", 
+    "Concavity", 
+    "Symmetry", 
+    "Class", 
+    "dist_from_new"
+]]
 ```
 
 Based on $K=5$ nearest neighbors with these three predictors we would classify 

--- a/source/classification1.md
+++ b/source/classification1.md
@@ -633,10 +633,10 @@ cancer["dist_from_new"] = (
      + (cancer["Concavity"] - new_obs_Concavity) ** 2
 )**(1/2)
 cancer.nsmallest(5, "dist_from_new")[[
-	"Perimeter", 
-	"Concavity", 
-	"Class", 
-	"dist_from_new"
+    "Perimeter", 
+    "Concavity", 
+    "Class", 
+    "dist_from_new"
 ]]
 ```
 

--- a/source/classification2.md
+++ b/source/classification2.md
@@ -606,18 +606,16 @@ knn_pipeline
 ```
 
 Now that we have a $K$-nearest neighbors classifier object, we can use it to
-predict the class labels for our test set.  We will use the `assign` method to 
-augment the original test data with a column of predictions, creating the
-`cancer_test_predictions` data frame. The `Class` variable contains the actual
+predict the class labels for our test set and
+augment the original test data with a column of predictions.
+The `Class` variable contains the actual
 diagnoses, while the `predicted` contains the predicted diagnoses from the
 classifier. Note that below we print out just the `ID`, `Class`, and `predicted`
 variables in the output data frame.
 
 ```{code-cell} ipython3
-cancer_test_predictions = cancer_test.assign(
-    predicted = knn_pipeline.predict(cancer_test[["Smoothness", "Concavity"]])
-)
-cancer_test_predictions[["ID", "Class", "predicted"]]
+cancer_test["predicted"] = knn_pipeline.predict(cancer_test[["Smoothness", "Concavity"]])
+cancer_test[["ID", "Class", "predicted"]]
 ```
 
 ### Evaluate performance
@@ -632,11 +630,11 @@ number of predictions. First we filter the rows to find the number of correct pr
 and then divide the number of rows with correct predictions by the total number of rows
 using the `shape` attribute.
 ```{code-cell} ipython3
-correct_preds = cancer_test_predictions[
-    cancer_test_predictions["Class"] == cancer_test_predictions["predicted"]
+correct_preds = cancer_test[
+    cancer_test["Class"] == cancer_test["predicted"]
 ]
 
-correct_preds.shape[0] / cancer_test_predictions.shape[0]
+correct_preds.shape[0] / cancer_test.shape[0]
 ```
 
 The `scitkit-learn` package also provides a more convenient way to do this using
@@ -669,15 +667,15 @@ arguments: the actual labels first, then the predicted labels second.
 
 ```{code-cell} ipython3
 pd.crosstab(
-    cancer_test_predictions["Class"],
-    cancer_test_predictions["predicted"]
+    cancer_test["Class"],
+    cancer_test["predicted"]
 )
 ```
 
 ```{code-cell} ipython3
 :tags: [remove-cell]
-_ctab = pd.crosstab(cancer_test_predictions["Class"],
-            cancer_test_predictions["predicted"]
+_ctab = pd.crosstab(cancer_test["Class"],
+            cancer_test["predicted"]
            )
 
 c11 = _ctab["Malignant"]["Malignant"]
@@ -1205,15 +1203,14 @@ We will also rename the parameter name column to be a bit more readable,
 and drop the now unused `std_test_score` column.
 
 ```{code-cell} ipython3
+accuracies_grid["sem_test_score"] = accuracies_grid["std_test_score"] / 10**(1/2)
 accuracies_grid = (
     accuracies_grid[[
         "param_kneighborsclassifier__n_neighbors",
         "mean_test_score",
-        "std_test_score"
+        "sem_test_score"
     ]]
-    .assign(sem_test_score=accuracies_grid["std_test_score"] / 10**(1/2))
     .rename(columns={"param_kneighborsclassifier__n_neighbors": "n_neighbors"})
-    .drop(columns=["std_test_score"])
 )
 accuracies_grid
 ```

--- a/source/clustering.md
+++ b/source/clustering.md
@@ -856,14 +856,14 @@ order to do that, we first need to augment our
 original `penguins` data frame with the cluster assignments. 
 We can access these using the `labels_` attribute of the clustering object 
 ("labels" is a common alternative term to "assignments" in clustering), and 
-add them to the data frame using `assign`.
+add them to the data frame.
 
 ```{code-cell} ipython3
-clustered_data = penguins.assign(cluster = penguin_clust[1].labels_)
-clustered_data
+penguins["cluster"] = penguin_clust[1].labels_
+penguins
 ```
 
-Now that we have the cluster assignments included in the `clustered_data` data frame, we can 
+Now that we have the cluster assignments included in the `penguins` data frame, we can 
 visualize them as shown in {numref}`cluster_plot`.
 Note that we are plotting the *un-standardized* data here; if we for some reason wanted to 
 visualize the *standardized* data, we would need to use the `fit` and `transform` functions
@@ -874,7 +874,7 @@ will treat the `cluster` variable as a nominal/categorical variable, and
 hence use a discrete color map for the visualization.
 
 ```{code-cell} ipython3
-cluster_plot=alt.Chart(clustered_data).mark_circle().encode(
+cluster_plot=alt.Chart(penguins).mark_circle().encode(
     x=alt.X("flipper_length_mm").title("Flipper Length").scale(zero=False),
     y=alt.Y("bill_length_mm").title("Bill Length").scale(zero=False),
     color=alt.Color("cluster:N").title("Cluster"),

--- a/source/inference.md
+++ b/source/inference.md
@@ -250,11 +250,11 @@ expect our sample proportions from this population to vary for samples of size 4
 
 We again use the `sample` to take samples of size 40 from our
 population of Airbnb listings. But this time we use a list comprehension
-to repeat an operation multiple time (as in the previous chapter).
-In this case we are taking 20,000 samples of size 40
-and to make it clear which rows in the data frame come
-which of the 20,000 samples,
-we also add a column called `replicate` with this information.
+to repeat the operation multiple times (as we did previously in {numref}`Chapter %s <clustering>`).
+In this case we repeat the operation 20,000 times to obtain 20,000 samples of size 40.
+To make it clear which rows in the data frame come
+which of the 20,000 samples, we also add a column called `replicate` with this information using the `assign` function,
+introduced previously in {numref}`Chapter %s <wrangling>`.
 The call to `concat` concatenates all the 20,000 data frames
 returned from the list comprehension into a single big data frame.
 

--- a/source/intro.md
+++ b/source/intro.md
@@ -646,7 +646,7 @@ ten_lang = arranged_lang.head(10)
 ten_lang
 ```
 
-## Adding and modifying columns using `assign`
+## Adding and modifying columns
 
 ```{index} assign
 ```
@@ -663,7 +663,7 @@ column by the total Canadian population according to the 2016
 census&mdash;i.e., 35,151,728&mdash;and multiply it by 100. We can perform
 this computation using the code `100 * ten_lang["mother_tongue"] / canadian_population`. 
 Then to store the result in a new column (or
-overwrite an existing column), we use the `assign` method. We specify the name of the new
+overwrite an existing column), we specify the name of the new
 column to create (or old column to modify), then the assignment symbol `=`, 
 and then the computation to store in that column. In this case, we will opt to
 create a new column called `mother_tongue_percent`. 
@@ -677,9 +677,17 @@ although the latter is much clearer!
 ```
 
 ```{code-cell} ipython3
+:tags: [remove-cell]
+# disable setting with copy warning
+# it's not important for this chapter and just distracting
+# only occurs here because we did a much earlier .loc operation that is being picked up below by the coln assignment
+pd.options.mode.chained_assignment = None
+```
+
+```{code-cell} ipython3
 canadian_population = 35_151_728
-ten_lang_percent = ten_lang.assign(mother_tongue_percent=100 * ten_lang["mother_tongue"] / canadian_population)
-ten_lang_percent
+ten_lang["mother_tongue_percent"] = 100 * ten_lang["mother_tongue"] / canadian_population
+ten_lang
 ```
 
 The `ten_lang_percent` data frame shows that

--- a/source/intro.md
+++ b/source/intro.md
@@ -646,6 +646,7 @@ ten_lang = arranged_lang.head(10)
 ten_lang
 ```
 
+(ch1-adding-modifying)=
 ## Adding and modifying columns
 
 ```{index} assign

--- a/source/regression1.md
+++ b/source/regression1.md
@@ -1025,12 +1025,12 @@ sacr_results = pd.DataFrame(sacr_gridsearch.cv_results_)
 sacr_results["sem_test_score"] = sacr_results["std_test_score"] / 5**(1/2)
 sacr_results["mean_test_score"] = -sacr_results["mean_test_score"]
 sacr_results = (
-	sacr_results[[
-		"param_kneighborsregressor__n_neighbors",
-		"mean_test_score",
-		"sem_test_score"
-	]]
-	.rename(columns={"param_kneighborsregressor__n_neighbors" : "n_neighbors"})
+    sacr_results[[
+        "param_kneighborsregressor__n_neighbors",
+        "mean_test_score",
+        "sem_test_score"
+    ]]
+    .rename(columns={"param_kneighborsregressor__n_neighbors" : "n_neighbors"})
 )
 
 # show only the row of minimum RMSPE

--- a/source/regression1.md
+++ b/source/regression1.md
@@ -899,10 +899,10 @@ base_plot = alt.Chart(sacramento).mark_circle(opacity=0.4).encode(
 
 # Add the predictions as a line
 sacr_preds_plot = base_plot + alt.Chart(
-	sqft_prediction_grid, 
-	title=f"K = {best_k_sacr}"
+    sqft_prediction_grid, 
+    title=f"K = {best_k_sacr}"
 ).mark_line(
-	color="#ff7f0e"
+    color="#ff7f0e"
 ).encode(
     x="sqft",
     y="predicted"

--- a/source/regression1.md
+++ b/source/regression1.md
@@ -294,16 +294,14 @@ of a house that is 2,000 square feet.
 ```
 
 ```{code-cell} ipython3
-nearest_neighbors = (
-    small_sacramento.assign(diff=(2000 - small_sacramento["sqft"]).abs())
-    .nsmallest(5, "diff")
-)
-
-nearest_neighbors
+small_sacramento["dist"] = (2000 - small_sacramento["sqft"]).abs()
+small_sacramento.nsmallest(5, "dist")
 ```
 
 ```{code-cell} ipython3
 :tags: [remove-cell]
+
+nearest_neighbors = small_sacramento.nsmallest(5, "dist")
 
 nn_plot = small_plot + rule
 
@@ -609,16 +607,15 @@ sacr_gridsearch.fit(
 )
 
 # Retrieve the CV scores
-sacr_results = pd.DataFrame(sacr_gridsearch.cv_results_)[[
-    "param_kneighborsregressor__n_neighbors",
-    "mean_test_score",
-    "std_test_score"
-]]
+sacr_results = pd.DataFrame(sacr_gridsearch.cv_results_)
+sacr_results["sem_test_score"] = sacr_results["std_test_score"] / 5**(1/2)
 sacr_results = (
-    sacr_results
-    .assign(sem_test_score=sacr_results["std_test_score"] / 5**(1/2))
+    sacr_results[[
+        "param_kneighborsregressor__n_neighbors",
+        "mean_test_score",
+        "sem_test_score"
+    ]]
     .rename(columns={"param_kneighborsregressor__n_neighbors": "n_neighbors"})
-    .drop(columns=["std_test_score"])
 )
 sacr_results
 ```
@@ -834,12 +831,10 @@ model uses a different default scoring metric than the RMSPE.
 ```{code-cell} ipython3
 from sklearn.metrics import mean_squared_error
 
-sacr_preds = sacramento_test.assign(
-    predicted = sacr_gridsearch.predict(sacramento_test)
-)
+sacramento_test["predicted"] = sacr_gridsearch.predict(sacramento_test)
 RMSPE = mean_squared_error(
-    y_true = sacr_preds["price"],
-    y_pred=sacr_preds["predicted"]
+    y_true = sacramento_test["price"],
+    y_pred = sacramento_test["predicted"]
 )**(1/2)
 RMSPE
 ```
@@ -890,9 +885,7 @@ sqft_prediction_grid = pd.DataFrame({
     "sqft": np.arange(sacramento["sqft"].min(), sacramento["sqft"].max(), 10)
 })
 # Predict the price for each of the sqft values in the grid
-sacr_preds = sqft_prediction_grid.assign(
-    predicted = sacr_gridsearch.predict(sqft_prediction_grid)
-)
+sqft_prediction_grid["predicted"] = sacr_gridsearch.predict(sqft_prediction_grid)
 
 # Plot all the houses
 base_plot = alt.Chart(sacramento).mark_circle(opacity=0.4).encode(
@@ -905,11 +898,14 @@ base_plot = alt.Chart(sacramento).mark_circle(opacity=0.4).encode(
 )
 
 # Add the predictions as a line
-sacr_preds_plot = base_plot + alt.Chart(sacr_preds, title=f"K = {best_k_sacr}").mark_line(
-    color="#ff7f0e"
+sacr_preds_plot = base_plot + alt.Chart(
+	sqft_prediction_grid, 
+	title=f"K = {best_k_sacr}"
+).mark_line(
+	color="#ff7f0e"
 ).encode(
-    x="sqft",
-    y="predicted"
+	x="sqft",
+	y="predicted"
 )
 
 sacr_preds_plot
@@ -1018,25 +1014,24 @@ sacr_gridsearch = GridSearchCV(
     cv=5,
     scoring="neg_root_mean_squared_error"
 )
+
 sacr_gridsearch.fit(
   sacramento_train[["sqft", "beds"]],
   sacramento_train["price"]
 )
 
 # retrieve the CV scores
-sacr_results = pd.DataFrame(sacr_gridsearch.cv_results_)[[
-    "param_kneighborsregressor__n_neighbors",
-    "mean_test_score",
-    "std_test_score"
-]]
-
-sacr_results = (
-    sacr_results
-    .assign(sem_test_score=sacr_results["std_test_score"] / 5**(1/2))
-    .rename(columns={"param_kneighborsregressor__n_neighbors" : "n_neighbors"})
-    .drop(columns=["std_test_score"])
-)
+sacr_results = pd.DataFrame(sacr_gridsearch.cv_results_)
+sacr_results["sem_test_score"] = sacr_results["std_test_score"] / 5**(1/2)
 sacr_results["mean_test_score"] = -sacr_results["mean_test_score"]
+sacr_results = (
+	sacr_results[[
+		"param_kneighborsregressor__n_neighbors",
+		"mean_test_score",
+		"sem_test_score"
+	]]
+	.rename(columns={"param_kneighborsregressor__n_neighbors" : "n_neighbors"})
+)
 
 # show only the row of minimum RMSPE
 sacr_results.nsmallest(1, "mean_test_score")
@@ -1069,12 +1064,10 @@ via the `predict` method of the fit `GridSearchCV` object. Finally, we will use 
 to compute the RMSPE.
 
 ```{code-cell} ipython3
-sacr_preds = sacramento_test.assign(
-    predicted = sacr_gridsearch.predict(sacramento_test)
-)
+sacramento_test["predicted"] = sacr_gridsearch.predict(sacramento_test)
 RMSPE_mult = mean_squared_error(
-    y_true = sacr_preds["price"], 
-    y_pred=sacr_preds["predicted"]
+    y_true = sacramento_test["price"], 
+    y_pred = sacramento_test["predicted"]
 )**(1/2)
 RMSPE_mult
 

--- a/source/regression1.md
+++ b/source/regression1.md
@@ -904,8 +904,8 @@ sacr_preds_plot = base_plot + alt.Chart(
 ).mark_line(
 	color="#ff7f0e"
 ).encode(
-	x="sqft",
-	y="predicted"
+    x="sqft",
+    y="predicted"
 )
 
 sacr_preds_plot

--- a/source/regression1.md
+++ b/source/regression1.md
@@ -295,13 +295,13 @@ of a house that is 2,000 square feet.
 
 ```{code-cell} ipython3
 small_sacramento["dist"] = (2000 - small_sacramento["sqft"]).abs()
-small_sacramento.nsmallest(5, "dist")
+nearest_neighbors = small_sacramento.nsmallest(5, "dist")
+nearest_neighbors
 ```
 
 ```{code-cell} ipython3
 :tags: [remove-cell]
 
-nearest_neighbors = small_sacramento.nsmallest(5, "dist")
 
 nn_plot = small_plot + rule
 

--- a/source/regression2.md
+++ b/source/regression2.md
@@ -436,14 +436,12 @@ we predict on the test data set to assess how well our model does.
 
 ```{code-cell} ipython3
 # make predictions
-sacr_preds = sacramento_test.assign(
-    predicted = lm.predict(sacramento_test[["sqft"]])
-)
+sacramento_test["predicted"] = lm.predict(sacramento_test[["sqft"]])
 
 # calculate RMSPE
 RMSPE = mean_squared_error(
-    y_true=sacr_preds["price"],
-    y_pred=sacr_preds["predicted"]
+    y_true = sacramento_test["price"],
+    y_pred = sacramento_test["predicted"]
 )**(1/2)
 
 RMSPE
@@ -478,9 +476,7 @@ so that we can qualitatively assess if the model seems to fit the data well.
 ```{code-cell} ipython3
 :tags: [remove-output]
 sqft_prediction_grid = sacramento[["sqft"]].agg(["min", "max"])
-sacr_preds = sqft_prediction_grid.assign(
-    predicted=lm.predict(sqft_prediction_grid)
-)
+sqft_prediction_grid["predicted"] = lm.predict(sqft_prediction_grid)
 
 all_points = alt.Chart(sacramento).mark_circle(opacity=0.4).encode(
     x=alt.X("sqft")
@@ -492,7 +488,7 @@ all_points = alt.Chart(sacramento).mark_circle(opacity=0.4).encode(
         .title("Price (USD)")
 )
 
-sacr_preds_plot = all_points + alt.Chart(sacr_preds).mark_line(
+sacr_preds_plot = all_points + alt.Chart(sqft_prediction_grid).mark_line(
     color="#ff7f0e"
 ).encode(
     x="sqft",
@@ -735,13 +731,11 @@ mlm.fit(
 Finally, we make predictions on the test data set to assess the quality of our model.
 
 ```{code-cell} ipython3
-sacr_preds = sacramento_test.assign(
-    predicted=mlm.predict(sacramento_test[["sqft","beds"]])
-)
+sacramento_test["predicted"] = mlm.predict(sacramento_test[["sqft","beds"]])
 
 lm_mult_test_RMSPE = mean_squared_error(
-    y_true=sacr_preds["price"], 
-    y_pred=sacr_preds["predicted"]
+    y_true = sacramento_test["price"], 
+    y_pred = sacramento_test["predicted"]
 )**(1/2)
 lm_mult_test_RMSPE
 ```

--- a/source/viz.md
+++ b/source/viz.md
@@ -610,7 +610,8 @@ can_lang
 
 ```{code-cell} ipython3
 :tags: ["remove-cell"]
-can_lang = can_lang[(can_lang["most_at_home"] > 0) & (can_lang["mother_tongue"] > 0)]
+# use only nonzero entries (to avoid issues with log scale), and wrap in a pd.DataFrame to prevent copy/view warnings later
+can_lang = pd.DataFrame(can_lang[(can_lang["most_at_home"] > 0) & (can_lang["mother_tongue"] > 0)]) 
 ```
 
 ```{index} altair; mark_circle
@@ -831,9 +832,9 @@ in the 2016 Canadian census
 was {glue:text}`english_mother_tongue` / {glue:text}`census_popn` $\times$
 100\% = {glue:text}`result`\%
 
-Below we use `assign` to calculate the percentage of people reporting a given
-language as their mother tongue and primary language at home for all the
-languages in the `can_lang` data set. Since the new columns are appended to the
+Below we assign the percentages of people reporting a given
+language as their mother tongue and primary language at home
+to two new columns in the `can_lang` data frame. Since the new columns are appended to the
 end of the data table, we selected the new columns after the transformation so
 you can clearly see the mutated output from the table.
 Note that we formatted the number for the Canadian population
@@ -846,10 +847,8 @@ and is just added for readability.
 
 ```{code-cell} ipython3
 canadian_population = 35_151_728
-can_lang = can_lang.assign(
-    mother_tongue_percent=(can_lang["mother_tongue"] / canadian_population) * 100,
-    most_at_home_percent=(can_lang["most_at_home"] / canadian_population) * 100
-)
+can_lang["mother_tongue_percent"] = can_lang["mother_tongue"] / canadian_population * 100
+can_lang["most_at_home_percent"] = can_lang["most_at_home"] / canadian_population * 100
 can_lang[["mother_tongue_percent", "most_at_home_percent"]]
 ```
 
@@ -1637,9 +1636,8 @@ done by providing the `title` to the facet function. Finally, and perhaps most
 subtly, even though it is easy to compare the experiments on this plot to one
 another, it is hard to get a sense of just how accurate all the experiments
 were overall. For example, how accurate is the value 800 on the plot, relative
-to the true speed of light?  To answer this question, we'll use the `assign`
-function to transform our data into a relative measure of error rather than
-an absolute measurement.
+to the true speed of light?  To answer this question, we'll
+transform our data to a relative measure of error rather than an absolute measurement.
 
 ```{code-cell} ipython3
 speed_of_light = 299792.458

--- a/source/wrangling.md
+++ b/source/wrangling.md
@@ -1655,7 +1655,9 @@ one would solve this problem in a less error-prone way using
 the `merge` function, which lets you combine two data frames. We will show you an
 example using `merge` at the end of the chapter!
 ```
-Once again we can also instead directly modify the `english_lang` data frame using column assignment.
+Instead of using the `assign` method we can directly modify the `english_lang` data frame using regular column assignment.
+This would be a more natural choice in this particular case,
+since the syntax is more convenient for simple column modifications and additions.
 ```{code-cell} ipython3
 :tags: [remove-cell]
 english_lang["city_pops"] = [4098927, 5928040, 1392609, 1321426, 2463431]

--- a/source/wrangling.md
+++ b/source/wrangling.md
@@ -800,7 +800,10 @@ It makes sense for `region`, `category`, and `language` to be stored as an
 above a numeric threshold of a column).
 That won't be possible if the variable is stored as a `object`.
 Fortunately, the `pandas.to_numeric` function provides a natural way to fix problems
-like this: it will convert the columns to the best numeric data types.
+like this: it will convert the columns to the best numeric data types. Note that below
+we *assign* the new numerical series to the `most_at_home` and `most_at_work` columns
+in `tidy_lang`; we have seen this syntax before in {numref}`ch1-adding-modifying`,
+and we will discuss it in more depth later in this chapter in {numref}`pandas-assign`.
 
 ```{code-cell} ipython3
 :tags: ["output_scroll"]

--- a/source/wrangling.md
+++ b/source/wrangling.md
@@ -1482,7 +1482,7 @@ region_lang
 ```{index} pandas.DataFrame; apply, pandas.DataFrame; loc[]
 ```
 
-We can simply call the `.as_type` function to apply it across the desired range of columns.
+We can simply call the `.astype` function to apply it across the desired range of columns.
 
 ```{code-cell} ipython3
 region_lang_nums = region_lang.loc[:, "mother_tongue":"lang_known"].astype("int32")

--- a/source/wrangling.md
+++ b/source/wrangling.md
@@ -1630,7 +1630,9 @@ five_cities
 ```
 The data frame above shows that the populations of the five cities in 2016 were
 5928040 (Toronto), 4098927 (Montréal),  2463431 (Vancouver), 1392609 (Calgary), and 1321426 (Edmonton).
-We will first add this information to a new data frame in a new column named `city_pops` by using `assign`.
+Next, we will add this information to a new data frame column called `city_pops`.
+Once again, we will illustrate how to do this using both regular column assignment
+and the  `assign` method, starting with the latter.
 Once again we specify the new column name (`city_pops`) as the argument, followed by the equal symbol `=`,
 and finally the data in the column.
 Note that the order of the rows in the `english_lang` data frame is Montréal, Toronto, Calgary, Edmonton, Vancouver.

--- a/source/wrangling.md
+++ b/source/wrangling.md
@@ -1565,7 +1565,7 @@ Remember to specify `axis=1` in the `apply` method so that we compute the row-wi
 ```{code-cell} ipython3
 :tags: ["output_scroll"]
 region_lang.assign(
-  maximum = region_lang_nums.apply(max, axis=1)
+  maximum=region_lang_nums.max(axis=1)
 )
 ```
 This data frame looks just like the previous one, except that it is a copy of `region_lang`, not `region_lang` itself; making further

--- a/source/wrangling.md
+++ b/source/wrangling.md
@@ -1710,7 +1710,7 @@ english_lang
 
 Let's return to the situation right before we added the city populations
 of Toronto, Montréal, Vancouver, Calgary, and Edmonton to the `english_lang` data frame. Before adding the new column, we had filtered
-our `region_lang` to create the `english_lang` data frame containing only English speakers in the five cities
+`region_lang` to create the `english_lang` data frame containing only English speakers in the five cities
 of interest.
 ```{code-cell} ipython3
 :tags: ["remove-cell"]

--- a/source/wrangling.md
+++ b/source/wrangling.md
@@ -1560,8 +1560,8 @@ To instead create an entirely new data frame, we can use the `assign` method and
 In this case we want to create one new column named `maximum`, so the argument
 to `assign` begins with `maximum= `.
 Then after the `=`, we specify what the contents of that new column
-should be. In this case we use `apply` just as we did in the previous section to give us the maximum values.
-Remember to specify `axis=1` in the `apply` method so that we compute the row-wise maximum value.
+should be. In this case we use `max` just as we did previously to give us the maximum values.
+Remember to specify `axis=1` in the `max` method so that we compute the row-wise maximum value.
 ```{code-cell} ipython3
 :tags: ["output_scroll"]
 region_lang.assign(
@@ -1777,7 +1777,6 @@ burning data science questions!
 | Function | Description |
 | ---      | ----------- |
 | `agg` | calculates aggregated summaries of inputs |
-| `apply` | allows you to apply function(s) to multiple columns/rows  |
 | `assign` | adds or modifies columns in a data frame  |
 | `groupby` |  allows you to apply function(s) to groups of rows |
 | `iloc` | subsets columns/rows of a data frame using integer indices |

--- a/source/wrangling.md
+++ b/source/wrangling.md
@@ -1470,7 +1470,7 @@ A transformation applied across many columns. The darker, top row of each table 
 
 For example, imagine that we wanted to convert all the numeric columns
 in the `region_lang` data frame from `int64` type to `int32` type
-using the `.as_type` function.
+using the `.astype` function.
 When we revisit the `region_lang` data frame,
 we can see that this would be the columns from `mother_tongue` to `lang_known`.
 

--- a/source/wrangling.md
+++ b/source/wrangling.md
@@ -1631,9 +1631,8 @@ five_cities
 The data frame above shows that the populations of the five cities in 2016 were
 5928040 (Toronto), 4098927 (Montréal),  2463431 (Vancouver), 1392609 (Calgary), and 1321426 (Edmonton).
 Next, we will add this information to a new data frame column called `city_pops`.
-Once again, we will illustrate how to do this using both regular column assignment
-and the  `assign` method, starting with the latter.
-Once again we specify the new column name (`city_pops`) as the argument, followed by the equal symbol `=`,
+Once again, we will illustrate how to do this using both the `assign` method and regular column assignment.
+We specify the new column name (`city_pops`) as the argument, followed by the equals symbol `=`,
 and finally the data in the column.
 Note that the order of the rows in the `english_lang` data frame is Montréal, Toronto, Calgary, Edmonton, Vancouver.
 So we will create a column called `city_pops` where we list the populations of those cities in that
@@ -1693,19 +1692,24 @@ the `merge` function, which lets you combine two data frames. We will show you a
 example using `merge` at the end of the chapter!
 ```
 
-Now we have a new column with the population for each city. Finally, we calculate the
-proportion of people who speak English the most at home by taking the ratio of the columns
-`most_at_home` and `city_pops`. Let's modify the `most_at_home` column directly; in this case
-we can just assign directly to the column.
-This is precisely what we did in {numref}`str-split`,
+Now we have a new column with the population for each city. Finally, we can convert all the numerical
+columns to proportions of people who speak English by taking the ratio of all the numerical columns
+with `city_pops`. Let's modify the `english_lang` column directly; in this case
+we can just assign directly to the data frame.
+This is similar to what we did in {numref}`str-split`,
 when we first read in the `"region_lang_top5_cities_messy.csv"` data and we needed to convert a few
-of the variables to numeric types.
-Note that it is again possible to instead use the `assign` function to produce a new data frame when modifying an existing column,
-although this is not commonly done.
+of the variables to numeric types. Here we assign to a range of columns simultaneously using `loc[]`.
+Note that it is again possible to instead use the `assign` function to produce a new data
+frame when modifying existing columns, although this is not commonly done.
+Note also that we use the `div` method with the argument `axis=0` to divide a range of columns in a data frame
+by the values in a single column&mdash;the basic division symbol `/` won't work in this case.
 
 ```{code-cell} ipython3
 :tags: ["output_scroll"]
-english_lang["most_at_home"] = english_lang["most_at_home"]/english_lang["city_pops"]
+english_lang.loc[:, "mother_tongue":"lang_known"] = english_lang.loc[
+    :,
+    "mother_tongue":"lang_known"
+    ].div(english_lang["city_pops"], axis=0)
 english_lang
 ```
 

--- a/source/wrangling.md
+++ b/source/wrangling.md
@@ -44,8 +44,7 @@ By the end of the chapter, readers will be able to do the following:
   - Recall and use the following functions for their
     intended data wrangling tasks:
       - `agg`
-      - `apply`
-      - `assign`
+      - `assign` (as well as regular column assignment)
       - `groupby`
       - `melt`
       - `pivot`
@@ -782,7 +781,7 @@ Is this data set now tidy? If we recall the three criteria for tidy data:
 
 We can see that this data now satisfies all three criteria, making it easier to
 analyze. But we aren't done yet! Although we can't see it in the data frame above, all of the variables are actually
-"object" data types. We can check this using the `info` method.
+`object` data types. We can check this using the `info` method.
 ```{code-cell} ipython3
 tidy_lang.info()
 ```
@@ -795,20 +794,21 @@ Python read these columns in as string types, and by default, `str.split` will
 return columns with the `object` data type.
 
 It makes sense for `region`, `category`, and `language` to be stored as an
-`object` type. However, suppose we want to apply any functions that treat the
+`object` type since they hold categorical values. However, suppose we want to apply any functions that treat the
 `most_at_home` and `most_at_work` columns as a number (e.g., finding rows
 above a numeric threshold of a column).
 That won't be possible if the variable is stored as an `object`.
-Fortunately, the `pandas.to_numeric` function provides a natural way to fix problems
-like this: it will convert the columns to the best numeric data types. Note that below
+Fortunately, the `astype` method from `pandas` provides a natural way to fix problems
+like this: it will convert the column to a selected data type. In this case, we choose the `int`
+data type to indicate that these variables contain integer counts. Note that below
 we *assign* the new numerical series to the `most_at_home` and `most_at_work` columns
 in `tidy_lang`; we have seen this syntax before in {numref}`ch1-adding-modifying`,
 and we will discuss it in more depth later in this chapter in {numref}`pandas-assign`.
 
 ```{code-cell} ipython3
 :tags: ["output_scroll"]
-tidy_lang["most_at_home"] = pd.to_numeric(tidy_lang["most_at_home"])
-tidy_lang["most_at_work"] = pd.to_numeric(tidy_lang["most_at_work"])
+tidy_lang["most_at_home"] = tidy_lang["most_at_home"].astype("int")
+tidy_lang["most_at_work"] = tidy_lang["most_at_work"].astype("int")
 tidy_lang
 ```
 

--- a/source/wrangling.md
+++ b/source/wrangling.md
@@ -1647,14 +1647,6 @@ english_lang.assign(
 )
 ```
 
-```{note}
-Inserting data manually in this is generally very error-prone and is not recommended.
-We do it here to demonstrate another usage of `assign` that does not involve `apply`.
-But in more advanced data wrangling,
-one would solve this problem in a less error-prone way using
-the `merge` function, which lets you combine two data frames. We will show you an
-example using `merge` at the end of the chapter!
-```
 Instead of using the `assign` method we can directly modify the `english_lang` data frame using regular column assignment.
 This would be a more natural choice in this particular case,
 since the syntax is more convenient for simple column modifications and additions.
@@ -1690,6 +1682,15 @@ For the rest of the book, we will silence that warning to help with readability.
 :tags: [remove-cell]
 # suppress for the rest of this chapter
 pd.options.mode.chained_assignment = None
+```
+
+```{note}
+Inserting the data column `[4098927, 5928040, ...]` manually as we did above is generally very error-prone and is not recommended.
+We do it here to demonstrate another usage of `assign` and regular column assignment.
+But in more advanced data wrangling,
+one would solve this problem in a less error-prone way using
+the `merge` function, which lets you combine two data frames. We will show you an
+example using `merge` at the end of the chapter!
 ```
 
 Now we have a new column with the population for each city. Finally, we calculate the

--- a/source/wrangling.md
+++ b/source/wrangling.md
@@ -798,7 +798,7 @@ It makes sense for `region`, `category`, and `language` to be stored as an
 `object` type. However, suppose we want to apply any functions that treat the
 `most_at_home` and `most_at_work` columns as a number (e.g., finding rows
 above a numeric threshold of a column).
-That won't be possible if the variable is stored as a `object`.
+That won't be possible if the variable is stored as an `object`.
 Fortunately, the `pandas.to_numeric` function provides a natural way to fix problems
 like this: it will convert the columns to the best numeric data types. Note that below
 we *assign* the new numerical series to the `most_at_home` and `most_at_work` columns

--- a/source/wrangling.md
+++ b/source/wrangling.md
@@ -1556,7 +1556,7 @@ the maximum value between `mother_tongue`,
 `most_at_home`, `most_at_work` and `lang_known` for each language
 and region, just as we specified! 
 
-To instead create an entirely new data frame with the `assign` method, we specify one argument for each column we want to create.
+To instead create an entirely new data frame, we can use the `assign` method and specify one argument for each column we want to create.
 In this case we want to create one new column named `maximum`, so the argument
 to `assign` begins with `maximum = `.
 Then after the `=`, we specify what the contents of that new column

--- a/source/wrangling.md
+++ b/source/wrangling.md
@@ -1558,7 +1558,7 @@ and region, just as we specified!
 
 To instead create an entirely new data frame, we can use the `assign` method and specify one argument for each column we want to create.
 In this case we want to create one new column named `maximum`, so the argument
-to `assign` begins with `maximum = `.
+to `assign` begins with `maximum= `.
 Then after the `=`, we specify what the contents of that new column
 should be. In this case we use `apply` just as we did in the previous section to give us the maximum values.
 Remember to specify `axis=1` in the `apply` method so that we compute the row-wise maximum value.

--- a/source/wrangling.md
+++ b/source/wrangling.md
@@ -1524,7 +1524,7 @@ we will use column assignment or the `assign` function to create a new column.
 This is discussed in the next section.
 
 ```{note}
-While `pandas` provides many methods (like `max`, `as_type`, etc.) that can be applied to a data frame,
+While `pandas` provides many methods (like `max`, `astype`, etc.) that can be applied to a data frame,
 sometimes you may want to apply your own function to multiple columns in a data frame. In this case
 you can use the more general [`apply`](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.apply.html) method.
 ```

--- a/source/wrangling.md
+++ b/source/wrangling.md
@@ -1536,8 +1536,8 @@ you can use the more general [`apply`](https://pandas.pydata.org/docs/reference/
 ```{index} pandas.DataFrame; []
 ```
 
-When we compute summary statistics with `agg` or apply functions using `apply`,
-those give us new data frames. But what if we want to append that information
+When we compute summary statistics or apply functions,
+a new data frame or series is created. But what if we want to append that information
 to an existing data frame? For example, say we wanted to compute the
 maximum value in each row of the `region_lang_nums` data frame using `apply`,
 and to append that as an additional column of the `region_lang` data frame.

--- a/source/wrangling.md
+++ b/source/wrangling.md
@@ -1539,7 +1539,7 @@ you can use the more general [`apply`](https://pandas.pydata.org/docs/reference/
 When we compute summary statistics or apply functions,
 a new data frame or series is created. But what if we want to append that information
 to an existing data frame? For example, say we wanted to compute the
-maximum value in each row of the `region_lang_nums` data frame using `apply`,
+maximum value in each row of the `region_lang_nums` data frame,
 and to append that as an additional column of the `region_lang` data frame.
 In this case, we have two options: we can either  create a new column within the `region_lang` data
 frame itself, or create an entirely new data frame
@@ -1547,7 +1547,7 @@ with the `assign` method. The first option we have seen already in earlier chapt
 the more commonly used pattern in practice:
 ```{code-cell} ipython3
 :tags: ["output_scroll"]
-region_lang["maximum"] = region_lang_nums.apply(max, axis=1)
+region_lang["maximum"] = region_lang_nums.max(axis=1)
 region_lang
 ```
 You can see above that the `region_lang` data frame now has an additional column named `maximum`.


### PR DESCRIPTION
- Closes #185  -- removed `assign` everywhere except in inference, where it is needed inside the list comprehension. I kept the introduction to `assign` in chapter 3, but shortened it and de-emphasized it compared with column assignment.
- Closes #100  -- lambdas and apply are now removed, as they didn't appear anywhere else in the book. I did still keep the section on applying transformations / row-wise operations, because I think it's still very useful material to see. I just used `pandas`'s pre-baked methods, with a `note` box for the `apply` method.
- Closes #130 no longer needed because assign is gone

~~possibly add mutation to ch1~~ turns out this was already done previously (...in fact I think it was me that did it...)

