### PR TITLE
Ibis: creating columns, fixing bugs

### DIFF
--- a/source/reading.md
+++ b/source/reading.md
@@ -721,8 +721,8 @@ response for us. So `ibis` does all the hard work of translating from Python to 
 we can just stick with Python!
 
 The `ibis` package provides lots of `pandas`-like tools for working with database tables.
-For example, we can look at the first few rows of the table by using the `head` function---and
-we won't forget to `execute` to see the result!
+For example, we can look at the first few rows of the table by using the `head` function,
+followed by `execute` to retrieve the response.
 
 ```{index} database; head, ibis;
 ```

--- a/source/reading.md
+++ b/source/reading.md
@@ -676,7 +676,7 @@ canlang_table
 
 Although it looks like we might have obtained the whole data frame from the database, we didn't!
 It's a *reference*; the data is still stored only in the SQLite database. The `canlang_table` object
-is an `AlchemyTable` (`ibis` is using `sqlalchemy` under the hood!), which, when printed, tells
+is a `DatabaseTable`, which, when printed, tells
 you which columns are available in the table. But unlike a usual `pandas` data frame,
 we do not immediately know how many rows are in the table. In order to find out how many
 rows there are, we have to send an SQL *query* (i.e., command) to the data base.


### PR DESCRIPTION
- Fixed bug (`AlchemyTable` is now `DatabaseTable`)
- Closes #236 -- we cannot introduce mutate here because mutate for basic data frames happens in ch3. I'm going to close this out with this PR because there isn't a way to do this nicely without propagating major changes elsewhere -- just not worth the effort.