### PR TITLE
Fix typo in text from "R" to "Python"; remove duplicated word "are"

### DIFF
--- a/source/reading.md
+++ b/source/reading.md
@@ -1137,7 +1137,7 @@ these. Tags are keywords that tell the web browser how to display or format
 the content. Above you can see that the information we want (`$800`) is stored
 between an opening and closing tag (`<span>` and `</span>`). In the opening
 tag, you can also see a very useful "class" (a special word that is sometimes
-included with opening tags): `class="result-price"`. Since we want R to
+included with opening tags): `class="result-price"`. Since we want Python to
 programmatically sort through all of the source code for the website to find
 apartment prices, maybe we can look for all the tags with the `"result-price"`
 class, and grab the information between the opening and closing tag. Indeed,

--- a/source/wrangling.md
+++ b/source/wrangling.md
@@ -115,7 +115,7 @@ A data frame storing data regarding the population of various regions in Canada.
 ```{index} Series 
 ```
 
-In Python, `pandas` **series** are are objects that can contain one or more elements (like a list).
+In Python, `pandas` **series** are objects that can contain one or more elements (like a list).
 They are a single column, are ordered, can be indexed, and can contain any data type.
 The `pandas` package uses `Series` objects to represent the columns in a data frame.
 `Series` can contain a mix of data types, but it is good practice to only include a single type in a series


### PR DESCRIPTION
When working through your book, I came across two small typos fixed in this PR
(I have just emailed about work in converting these to PreTeXt where I came across these minor typos - my apologies that I forgot to mention these items, I noticed just as I hit send and didn't want to fill up your inbox too much!)

- Fixed "R" to say "Python" (presumably legacy from R version)
- Removed duplicated "are" in Ch3.3.2